### PR TITLE
Security hardening (SNOW-3712074) plus perf/telemetry and temporal support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -166,3 +166,4 @@ cython_debug/
 Support/
 zip_build
 CONTRIBUTING.md
+/.cursor

--- a/__init__.py
+++ b/__init__.py
@@ -89,7 +89,7 @@ def classFactory(iface):  # pylint: disable=invalid-name
                 "Snowflake Connector",
                 "Required dependencies missing. See Log Messages for details.",
             )
-        except Exception:
+        except Exception:  # nosec B110 - message bar is best-effort; never block plugin bootstrap if iface is unavailable
             pass
         return _StubPlugin()
 
@@ -118,6 +118,6 @@ def classFactory(iface):  # pylint: disable=invalid-name
                 "Snowflake Connector",
                 "Plugin failed to load. See Log Messages for details.",
             )
-        except Exception:
+        except Exception:  # nosec B110 - message bar is best-effort; never block plugin bootstrap if iface is unavailable
             pass
         return _StubPlugin()

--- a/dialogs/sf_connection_string_dialog.py
+++ b/dialogs/sf_connection_string_dialog.py
@@ -148,7 +148,7 @@ class SFConnectionStringDialog(QDialog, Ui_QgsPgNewConnectionBase):
                 method_to_call = getattr(widget, method_name)
                 if method_to_call() == "":
                     unfilled_required_fields.append(f"- {field_name}\n")
-            except Exception as _:
+            except Exception as _:  # nosec B110 - skipping a widget that does not expose the expected getter is intentional; field simply isn't treated as required
                 pass
 
         return unfilled_required_fields

--- a/dialogs/sf_connection_string_dialog.py
+++ b/dialogs/sf_connection_string_dialog.py
@@ -179,7 +179,11 @@ class SFConnectionStringDialog(QDialog, Ui_QgsPgNewConnectionBase):
                 self.cbxConnectionType.currentText() == "Default Authentication"
             )
 
-            if is_default_auth:
+            # SNOW-3712079: only persist a cleartext password when the user is
+            # NOT using the encrypted (Configurations) tab. Capturing it
+            # unconditionally leaked the password into the world-readable INI
+            # even after the user opted into QgsAuthManager storage.
+            if is_default_auth and not config_tab_selected:
                 conn_settings["password"] = self.mAuthSettings.password()
 
             if config_tab_selected:

--- a/dialogs/sf_new_table_dialog.py
+++ b/dialogs/sf_new_table_dialog.py
@@ -145,7 +145,7 @@ class SFNewTableDialog(QDialog, Ui_QgsNewVectorTableDialogBase):
                     FROM INFORMATION_SCHEMA.COLUMNS
                     WHERE table_catalog ILIKE {quote_literal(auth_information["database"])}
                     ORDER BY TABLE_SCHEMA
-                """
+                """  # nosec B608 - value escaped via quote_literal
 
         sf_data_provider = SFDataProvider(auth_information)
 

--- a/dialogs/sf_spatial_filter_dialog.py
+++ b/dialogs/sf_spatial_filter_dialog.py
@@ -146,7 +146,7 @@ class SFSpatialFilterDialog(QDialog):
         qt = quote_identifier(self.table)
         qg = quote_identifier(self.geo_column)
 
-        sql = f"SELECT * FROM {qs}.{qt}"
+        sql = f"SELECT * FROM {qs}.{qt}"  # nosec B608 - identifiers escaped via quote_identifier
 
         conditions = []
 

--- a/entities/sf_data_item.py
+++ b/entities/sf_data_item.py
@@ -422,7 +422,7 @@ WHERE table_catalog ILIKE {quote_literal(auth_information["database"])}
 {schema_filter}
 {table_filter}
 {geo_type_filter}
-ORDER BY {column_name}"""
+ORDER BY {column_name}"""  # nosec B608 - column_name is a fixed literal; values escaped via quote_literal; filters assembled above with quote_literal
 
         return auth_information, column_name, children_item_type, query
 

--- a/entities/sf_data_item.py
+++ b/entities/sf_data_item.py
@@ -97,7 +97,7 @@ class SFDataItem(QgsDataItem):
         """
         children: typing.List["SFDataItem"] = []
         try:
-            if self.item_type == "field":
+            if self.item_type in ("field", "table_no_geom"):
                 pass
             elif self.item_type == "root":
                 self.create_root_item(children)
@@ -106,6 +106,9 @@ class SFDataItem(QgsDataItem):
 
             elif self.item_type == "table":
                 self.create_table_item(children)
+
+            elif self.item_type == "table_group":
+                self.create_table_group_item(children)
 
             elif self.item_type == "fields":
                 self.create_fields_item(children)
@@ -254,20 +257,14 @@ class SFDataItem(QgsDataItem):
                 clean_name="",
                 geom_type="",
             )
+            # Stash the table names so the group builds its children lazily in
+            # createChildren(). Adding them eagerly via addChildItem() left the
+            # group unpopulated, so expanding it re-ran createChildren() and fell
+            # through to _get_query_metadata() with an unhandled item_type. See
+            # issue #118.
+            group_item.non_geo_tables = sorted(non_geo_tables)
             children.append(group_item)
-            
-            # Add individual non-geo tables as children of the group
-            for table_name in sorted(non_geo_tables):
-                item = self._create_data_item(
-                    name=table_name,
-                    type="table_no_geom",
-                    connection_name=self.connection_name,
-                    clean_name=table_name,
-                    geom_type="",
-                )
-                item.geom_column = None
-                group_item.addChildItem(item, refresh=False)
-        
+
         # If no tables found at all, show informative message
         if not geo_table_names and not non_geo_tables:
             error_item = QgsErrorItem(
@@ -276,6 +273,32 @@ class SFDataItem(QgsDataItem):
                 f"{self.path()}/error"
             )
             children.append(error_item)
+
+    def create_table_group_item(self, children: typing.List["SFDataItem"]) -> None:
+        """
+        Creates the child items for the "Tables (no geometry)" group.
+
+        The non-geometry table names are stashed on the group item by
+        create_schema_item so they can be built lazily here, avoiding the
+        _get_query_metadata() path that does not handle this item type.
+
+        Args:
+            children (typing.List["SFDataItem"]): A list to which the created
+                                                  table items will be appended.
+
+        Returns:
+            None
+        """
+        for table_name in getattr(self, "non_geo_tables", []):
+            item = self._create_data_item(
+                name=table_name,
+                type="table_no_geom",
+                connection_name=self.connection_name,
+                clean_name=table_name,
+                geom_type="",
+            )
+            item.geom_column = None
+            children.append(item)
 
     def create_table_item(self, children: typing.List["SFDataItem"]) -> None:
         """

--- a/entities/sf_data_item.py
+++ b/entities/sf_data_item.py
@@ -27,7 +27,7 @@ from ..helpers.utils import (
 from ..helpers.sql import quote_literal
 from ..tasks.sf_convert_column_to_layer_task import SFConvertColumnToLayerTask
 from ..dialogs.sf_connection_string_dialog import SFConnectionStringDialog
-from qgis.PyQt.QtCore import pyqtSignal
+from qgis.PyQt.QtCore import pyqtSignal, Qt
 from qgis.core import (
     QgsDataItem,
     Qgis,
@@ -473,15 +473,21 @@ ORDER BY {column_name}"""  # nosec B608 - column_name is a fixed literal; values
         """
         try:
             if self.item_type == "table_no_geom":
-                # Show message for non-geometry tables
-                QMessageBox.information(
-                    None,
-                    "No Geometry Column",
+                # SNOW-3712087: the table name is server-controlled and shown on
+                # the first line. Force plain text so Qt::mightBeRichText() can
+                # never switch the label to rich text and auto-load a UNC <img>
+                # (forced SMB auth / NTLM hash leak).
+                msg_box = QMessageBox(None)
+                msg_box.setIcon(QMessageBox.Icon.Information)
+                msg_box.setWindowTitle("No Geometry Column")
+                msg_box.setTextFormat(Qt.TextFormat.PlainText)
+                msg_box.setText(
                     f"Table '{self.clean_name}' has no geometry column and cannot be displayed on the map.\n\n"
                     "You can:\n"
                     "• Use 'Execute SQL' to query this table\n"
-                    "• View/edit attributes via Processing tools",
+                    "• View/edit attributes via Processing tools"
                 )
+                msg_box.exec()
                 return True
             if self.item_type == "table" and not self.geom_column:
                 return False

--- a/entities/sf_dynamic_connection_combo_box_widget.py
+++ b/entities/sf_dynamic_connection_combo_box_widget.py
@@ -137,7 +137,7 @@ class DynamicConnectionComboBoxWidget(WidgetWrapper):
             if not self._prefilled:
                 self._prefilled = True
                 self._prefill_from_snowflake_layer()
-        except Exception:
+        except Exception:  # nosec B110 - prefill is a UX convenience; must never prevent the dialog from opening if the layer metadata is unexpected
             pass
 
     def _prefill_from_snowflake_layer(self):

--- a/helpers/data_base.py
+++ b/helpers/data_base.py
@@ -34,7 +34,7 @@ def get_schema_iterator(settings: QSettings, connection_name: str) -> SFFeatureI
     query = f"""SELECT DISTINCT SCHEMA_NAME
 FROM INFORMATION_SCHEMA.SCHEMATA
 WHERE CATALOG_NAME ILIKE {quote_literal(auth_information["database"])}
-ORDER BY SCHEMA_NAME"""
+ORDER BY SCHEMA_NAME"""  # nosec B608 - value escaped via quote_literal
 
     sf_data_provider.load_data(query, connection_name)
     return sf_data_provider.get_feature_iterator()
@@ -78,9 +78,9 @@ def filter_geo_columns(
                 (SELECT H3_IS_VALID_CELL({column})
                 FROM {table}
                 WHERE {column} IS NOT NULL
-                LIMIT 1)""")
+                LIMIT 1)""")  # nosec B608 - table/column sanitized via qualified_table_name/quote_identifier
     if len(number_queries) > 0:
-        query = f"SELECT {','.join(number_queries)}"
+        query = f"SELECT {','.join(number_queries)}"  # nosec B608 - subqueries pre-sanitized above
         result = sf_data_provider.execute_query(query, connection_name).fetchall()[0]
         for i in range(len(result)):
             if result[i]:
@@ -111,7 +111,7 @@ def get_table_geo_columns(
 FROM INFORMATION_SCHEMA.COLUMNS
 WHERE TABLE_CATALOG ILIKE {quote_literal(sf_data_provider.connection_params["database"])}
 AND TABLE_SCHEMA ILIKE {quote_literal(table_name)}
-ORDER BY TABLE_NAME, COLUMN_NAME"""
+ORDER BY TABLE_NAME, COLUMN_NAME"""  # nosec B608 - values escaped via quote_literal
 
     sf_data_provider.load_data(schema_selected_query, connection_name)
     columns = sf_data_provider.get_feature_iterator()
@@ -142,7 +142,7 @@ def get_geo_columns(
 FROM INFORMATION_SCHEMA.COLUMNS
 WHERE TABLE_CATALOG ILIKE {quote_literal(sf_data_provider.connection_params["database"])}
 AND DATA_TYPE IN ('GEOGRAPHY', 'GEOMETRY', 'NUMBER', 'TEXT')
-ORDER BY TABLE_NAME, COLUMN_NAME"""
+ORDER BY TABLE_NAME, COLUMN_NAME"""  # nosec B608 - value escaped via quote_literal
 
     sf_data_provider.load_data(schema_selected_query, connection_name)
     columns = sf_data_provider.get_feature_iterator()
@@ -177,7 +177,7 @@ FROM INFORMATION_SCHEMA.COLUMNS
 WHERE TABLE_CATALOG ILIKE {quote_literal(auth_information["database"])}
 AND TABLE_SCHEMA ILIKE {quote_literal(schema_data_item.clean_name)}
 AND TABLE_NAME ILIKE {quote_literal(table_data_item.clean_name)}
-ORDER BY COLUMN_NAME"""
+ORDER BY COLUMN_NAME"""  # nosec B608 - values escaped via quote_literal
 
     sf_data_provider.load_data(query, connection_name)
     return sf_data_provider.get_feature_iterator()
@@ -202,7 +202,7 @@ def get_table_iterator(settings: QSettings, connection_name: str, schema_name: s
 FROM INFORMATION_SCHEMA.TABLES
 WHERE table_catalog ILIKE {quote_literal(auth_information["database"])}
 AND TABLE_SCHEMA ILIKE {quote_literal(schema_name)}
-ORDER BY TABLE_NAME"""
+ORDER BY TABLE_NAME"""  # nosec B608 - values escaped via quote_literal
 
     sf_data_provider.load_data(query, connection_name)
     return sf_data_provider.get_feature_iterator()
@@ -264,7 +264,7 @@ def get_columns_cursor(
         AND TABLE_SCHEMA ILIKE {quote_literal(schema)}
         AND TABLE_NAME ILIKE {quote_literal(table)}
         ORDER BY COLUMN_NAME
-    """
+    """  # nosec B608 - values escaped via quote_literal
     return sf_data_provider.execute_query(
         query=query_select_columns, connection_name=connection_name
     )
@@ -361,7 +361,7 @@ def get_count_schemas(
     query_search_public_schema = f"""SELECT DISTINCT SCHEMA_NAME
 FROM INFORMATION_SCHEMA.SCHEMATA
 WHERE CATALOG_NAME ILIKE {quote_literal(data_base_name)}
-AND SCHEMA_NAME ILIKE {quote_literal(schema_name)}"""
+AND SCHEMA_NAME ILIKE {quote_literal(schema_name)}"""  # nosec B608 - values escaped via quote_literal
     return __get_cur_count(settings, connection_name, query_search_public_schema)
 
 
@@ -406,7 +406,7 @@ def get_count_tables(
 FROM INFORMATION_SCHEMA.TABLES
 WHERE TABLE_CATALOG ILIKE {quote_literal(database_name)}
 AND TABLE_SCHEMA ILIKE {quote_literal(schema_name)}
-AND TABLE_NAME ILIKE {quote_literal(table_name)}"""
+AND TABLE_NAME ILIKE {quote_literal(table_name)}"""  # nosec B608 - values escaped via quote_literal
 
     return __get_cur_count(settings, connection_name, query_search_table)
 
@@ -441,7 +441,7 @@ def get_srid_from_table_geo_column(
     """
     connection_manager: SFConnectionManager = SFConnectionManager.get_instance()
     query_srid = (
-        f'SELECT ANY_VALUE(ST_SRID({quote_identifier(geo_column_name)})) '
+        f'SELECT ANY_VALUE(ST_SRID({quote_identifier(geo_column_name)})) '  # nosec B608 - identifiers escaped via quote_identifier
         f'FROM {quote_identifier(table_name)} WHERE {quote_identifier(geo_column_name)} IS NOT NULL'
     )
     cur = connection_manager.execute_query(
@@ -499,7 +499,7 @@ def get_geo_column_type(
     """
     connection_manager: SFConnectionManager = SFConnectionManager.get_instance()
     query_geo_column_type = (
-        "SELECT DISTINCT DATA_TYPE "
+        "SELECT DISTINCT DATA_TYPE "  # nosec B608 - values escaped via quote_literal
         "FROM INFORMATION_SCHEMA.COLUMNS "
         f"WHERE TABLE_CATALOG ILIKE {quote_literal(context_information['database_name'])} "
         f"AND TABLE_SCHEMA ILIKE {quote_literal(context_information['schema_name'])} "
@@ -574,7 +574,7 @@ def get_srid_from_sql_query_geo_column(
 ) -> int:
     connection_manager: SFConnectionManager = SFConnectionManager.get_instance()
     query_srid = (
-        f'SELECT ANY_VALUE(ST_SRID({quote_identifier(context_information["geo_column_name"])})) '
+        f'SELECT ANY_VALUE(ST_SRID({quote_identifier(context_information["geo_column_name"])})) '  # nosec B608 - identifier escaped via quote_identifier; query wrapped in subquery
         f'FROM ({query}) WHERE {quote_identifier(context_information["geo_column_name"])} IS NOT NULL'
     )
     cur = connection_manager.execute_query(
@@ -616,7 +616,7 @@ def get_geo_types_from_geo_json_column(
     """
     connection_manager: SFConnectionManager = SFConnectionManager.get_instance()
     query_geo_type = (
-        f'SELECT DISTINCT ST_ASGEOJSON({quote_identifier(column)}):type::string '
+        f'SELECT DISTINCT ST_ASGEOJSON({quote_identifier(column)}):type::string '  # nosec B608 - identifier escaped via quote_identifier; from_clause is caller-quoted
         f'FROM {from_clause} WHERE {quote_identifier(column)} IS NOT NULL'
     )
     cur = connection_manager.execute_query(
@@ -686,7 +686,7 @@ def check_from_clause_exceeds_size(
         bool: True if the number of rows exceeds the limit size, False otherwise.
     """
     connection_manager: SFConnectionManager = SFConnectionManager.get_instance()
-    query = f"SELECT count(*) FROM {from_clause}"
+    query = f"SELECT count(*) FROM {from_clause}"  # nosec B608 - from_clause is caller-quoted via quote_identifier or subquery
     cur = connection_manager.execute_query(
         connection_name=context_information["connection_name"],
         query=query,
@@ -745,7 +745,7 @@ def get_limit_sql_query(
     connection_manager: SFConnectionManager = SFConnectionManager.get_instance()
     cur_desc = connection_manager.execute_query(
         connection_name=context_information["connection_name"],
-        query=f"SELECT * FROM ({query}) LIMIT 0",
+        query=f"SELECT * FROM ({query}) LIMIT 0",  # nosec B608 - query is wrapped in subquery; LIMIT is a constant
         context_information=context_information,
     )
     cur_description = cur_desc.description
@@ -781,7 +781,7 @@ def get_limit_sql_query(
                 }
         h3_query_any_value_columns.append(h3_query_any_value_column_value)
 
-    sub_query = f"SELECT {query_columns} FROM ({query}) LIMIT {limit}"
+    sub_query = f"SELECT {query_columns} FROM ({query}) LIMIT {limit}"  # nosec B608 - query_columns built from quoted identifiers; limit is an int; query wrapped in subquery
     cur = connection_manager.execute_query(
         connection_name=context_information["connection_name"],
         query=sub_query,
@@ -815,7 +815,7 @@ def get_h3_columns_from_query(
         typing.List: A list containing the rows of the result set from the executed sub-query.
     """
     connection_manager: SFConnectionManager = SFConnectionManager.get_instance()
-    sub_query = f"SELECT {generate_query_columns(query_columns)} FROM (SELECT * FROM ({query}) LIMIT 1)"
+    sub_query = f"SELECT {generate_query_columns(query_columns)} FROM (SELECT * FROM ({query}) LIMIT 1)"  # nosec B608 - generated columns use quoted aliases; query wrapped in subquery
     cur = None
     try:
         cur = connection_manager.execute_query(
@@ -897,7 +897,7 @@ def get_table_columns(
     """
     connection_manager: SFConnectionManager = SFConnectionManager.get_instance()
     query_table_columns = (
-        "SELECT COLUMN_NAME "
+        "SELECT COLUMN_NAME "  # nosec B608 - values escaped via quote_literal
         "FROM INFORMATION_SCHEMA.COLUMNS "
         f"WHERE TABLE_CATALOG ILIKE {quote_literal(context_information['database_name'])} "
         f"AND TABLE_SCHEMA ILIKE {quote_literal(context_information['schema_name'])} "
@@ -932,7 +932,7 @@ def check_column_has_duplicates(
         f"{quote_identifier(context_information['table_name'])}"
     )
     query = (
-        f"SELECT COUNT(*) - COUNT(DISTINCT {quote_identifier(column_name)}) "
+        f"SELECT COUNT(*) - COUNT(DISTINCT {quote_identifier(column_name)}) "  # nosec B608 - identifiers escaped via quote_identifier
         f"FROM {fq_table}"
     )
     cur = connection_manager.execute_query(
@@ -960,7 +960,7 @@ def update_table_feature(
     try:
         connection_manager: SFConnectionManager = SFConnectionManager.get_instance()
         update_sql = (
-            f"UPDATE {quote_identifier(context_information['table_name'])} "
+            f"UPDATE {quote_identifier(context_information['table_name'])} "  # nosec B608 - identifiers escaped via quote_identifier; values bound as params
             f"SET {quote_identifier(context_information['column_geom'])} = %s "
             f"WHERE {quote_identifier(context_information['primary_key_name'])} = %s"
         )
@@ -1000,7 +1000,7 @@ def update_table_attributes(
     try:
         connection_manager: SFConnectionManager = SFConnectionManager.get_instance()
         sql = (
-            f"UPDATE {quote_identifier(context_information['table_name'])} "
+            f"UPDATE {quote_identifier(context_information['table_name'])} "  # nosec B608 - identifiers escaped via quote_identifier; set_clauses built from quoted identifiers; values bound as params
             f"SET {', '.join(set_clauses)} "
             f"WHERE {quote_identifier(context_information['primary_key_name'])} = %s"
         )
@@ -1033,7 +1033,7 @@ def insert_table_feature(
         cols = ", ".join(quote_identifier(c) for c in column_names)
         placeholders = ", ".join(["%s"] * len(column_names))
         sql = (
-            f"INSERT INTO {quote_identifier(context_information['table_name'])} "
+            f"INSERT INTO {quote_identifier(context_information['table_name'])} "  # nosec B608 - identifiers escaped via quote_identifier; placeholders are literal '%s'; values bound as params
             f"({cols}) VALUES ({placeholders})"
         )
 
@@ -1063,7 +1063,7 @@ def delete_table_features(
         connection_manager: SFConnectionManager = SFConnectionManager.get_instance()
         placeholders = ", ".join(["%s"] * len(pk_values))
         sql = (
-            f"DELETE FROM {quote_identifier(context_information['table_name'])} "
+            f"DELETE FROM {quote_identifier(context_information['table_name'])} "  # nosec B608 - identifiers escaped via quote_identifier; placeholders are literal '%s'; values bound as params
             f"WHERE {quote_identifier(context_information['primary_key_name'])} "
             f"IN ({placeholders})"
         )
@@ -1143,7 +1143,7 @@ def get_next_primary_key_value(
     try:
         connection_manager: SFConnectionManager = SFConnectionManager.get_instance()
         sql = (
-            f"SELECT COALESCE(MAX({quote_identifier(pk_column)}), 0) + 1 "
+            f"SELECT COALESCE(MAX({quote_identifier(pk_column)}), 0) + 1 "  # nosec B608 - identifiers escaped via quote_identifier
             f"FROM {quote_identifier(table_name)}"
         )
         cur = connection_manager.execute_query(

--- a/helpers/data_base.py
+++ b/helpers/data_base.py
@@ -472,7 +472,7 @@ def get_type_from_table_geo_column(
     """
     return get_geo_types_from_geo_json_column(
         column=geo_column_name,
-        from_clause=table_name,
+        from_clause=quote_identifier(table_name),
         context_information=context_information,
     )
 
@@ -519,6 +519,54 @@ def get_geo_column_type(
 from .limits import limit_size_for_type, limit_size_for_table
 
 
+def get_cheap_row_count(
+    context_information: dict,
+) -> typing.Optional[int]:
+    """Best-effort fast row count via ``INFORMATION_SCHEMA.TABLES.ROW_COUNT``.
+
+    Snowflake maintains ``ROW_COUNT`` on base tables without scanning them, so
+    this is effectively free compared to ``SELECT COUNT(*)``. Returns ``None``
+    when the row count is unavailable (views, external tables, temporary
+    tables, or missing catalog/schema info) so the caller can fall back to a
+    real ``COUNT(*)`` probe.
+    """
+    database_name = context_information.get("database_name")
+    schema_name = context_information.get("schema_name")
+    table_name = context_information.get("table_name")
+    if not database_name or not schema_name or not table_name:
+        return None
+    connection_manager: SFConnectionManager = SFConnectionManager.get_instance()
+    query = (
+        "SELECT ROW_COUNT FROM INFORMATION_SCHEMA.TABLES "  # nosec B608 - values escaped via quote_literal
+        f"WHERE TABLE_CATALOG ILIKE {quote_literal(database_name)} "
+        f"AND TABLE_SCHEMA ILIKE {quote_literal(schema_name)} "
+        f"AND TABLE_NAME ILIKE {quote_literal(table_name)} "
+        "AND TABLE_TYPE = 'BASE TABLE' "
+        "AND ROW_COUNT IS NOT NULL"
+    )
+    try:
+        cur = connection_manager.execute_query(
+            connection_name=context_information["connection_name"],
+            query=query,
+            context_information=context_information,
+        )
+        row = cur.fetchone()
+        cur.close()
+    except Exception as e:
+        QgsMessageLog.logMessage(
+            f"get_cheap_row_count lookup failed: {e}",
+            "Snowflake Plugin",
+            Qgis.MessageLevel.Info,
+        )
+        return None
+    if not row or row[0] is None:
+        return None
+    try:
+        return int(row[0])
+    except (ValueError, TypeError):
+        return None
+
+
 def check_table_exceeds_size(
     context_information: dict,
 ) -> bool:
@@ -535,6 +583,10 @@ def check_table_exceeds_size(
     """
 
     limit_size = limit_size_for_table(context_information=context_information)
+    # A4: avoid a blocking COUNT(*) when Snowflake already tracks the row count.
+    cheap = get_cheap_row_count(context_information)
+    if cheap is not None:
+        return cheap > limit_size
     return check_from_clause_exceeds_size(
         from_clause=quote_identifier(context_information["table_name"]),
         context_information=context_information,
@@ -866,6 +918,57 @@ def generate_query_columns(
     return ", ".join(col_map)
 
 
+def get_declared_primary_key(
+    context_information: dict,
+) -> typing.Optional[str]:
+    """Return the single column name of a table's declared primary key, or None.
+
+    Uses ``SHOW PRIMARY KEYS IN TABLE <db>.<schema>.<table>``. Returns ``None``
+    when the table has no declared PK or when the PK is composite (the rest
+    of the provider only supports a single-column PK).
+    """
+    database_name = context_information.get("database_name")
+    schema_name = context_information.get("schema_name")
+    table_name = context_information.get("table_name")
+    if not database_name or not schema_name or not table_name:
+        return None
+    connection_manager: SFConnectionManager = SFConnectionManager.get_instance()
+    fq_table = (
+        f"{quote_identifier(database_name)}."
+        f"{quote_identifier(schema_name)}."
+        f"{quote_identifier(table_name)}"
+    )
+    query = f"SHOW PRIMARY KEYS IN TABLE {fq_table}"
+    try:
+        cur = connection_manager.execute_query(
+            connection_name=context_information["connection_name"],
+            query=query,
+            context_information=context_information,
+        )
+        # SHOW PRIMARY KEYS column order is stable:
+        # created_on, database_name, schema_name, table_name, column_name, ...
+        column_name_idx = 4
+        for desc in cur.description:
+            if desc[0].lower() == "column_name":
+                column_name_idx = cur.description.index(desc)
+                break
+        rows = cur.fetchall()
+        cur.close()
+    except Exception as e:
+        QgsMessageLog.logMessage(
+            f"get_declared_primary_key lookup failed: {e}",
+            "Snowflake Plugin",
+            Qgis.MessageLevel.Info,
+        )
+        return None
+    if not rows or len(rows) != 1:
+        return None
+    try:
+        return str(rows[0][column_name_idx])
+    except (IndexError, TypeError):
+        return None
+
+
 def get_table_columns(
     context_information: dict,
 ) -> typing.List[typing.Tuple[str]]:
@@ -945,6 +1048,17 @@ def check_column_has_duplicates(
     return row[0] > 0
 
 
+def _edit_op_tag(context_information: dict) -> str:
+    """Build the QUERY_TAG payload used for every plugin-issued DML (E3)."""
+    from ..managers.sf_connection_manager import build_op_tag
+    return build_op_tag(
+        "edit",
+        connection_name=context_information.get("connection_name"),
+        schema=context_information.get("schema_name"),
+        table=context_information.get("table_name"),
+    )
+
+
 def update_table_feature(
     context_information: dict,
 ) -> bool:
@@ -975,6 +1089,7 @@ def update_table_feature(
             query=update_sql,
             params=params,
             context_information=context_information,
+            op_tag=_edit_op_tag(context_information),
         )
 
         cur.close()
@@ -1010,6 +1125,7 @@ def update_table_attributes(
             query=sql,
             params=params,
             context_information=context_information,
+            op_tag=_edit_op_tag(context_information),
         )
         cur.close()
         return None
@@ -1042,6 +1158,7 @@ def insert_table_feature(
             query=sql,
             params=params,
             context_information=context_information,
+            op_tag=_edit_op_tag(context_information),
         )
         cur.close()
         return None
@@ -1073,6 +1190,7 @@ def delete_table_features(
             query=sql,
             params=tuple(pk_values),
             context_information=context_information,
+            op_tag=_edit_op_tag(context_information),
         )
         cur.close()
         return None
@@ -1093,12 +1211,14 @@ def alter_table_add_columns(
     try:
         connection_manager: SFConnectionManager = SFConnectionManager.get_instance()
         table = quote_identifier(context_information["table_name"])
+        edit_tag = _edit_op_tag(context_information)
         for col_name, col_type in columns:
             sql = f"ALTER TABLE {table} ADD COLUMN {quote_identifier(col_name)} {col_type}"
             cur = connection_manager.execute_query(
                 connection_name=context_information["connection_name"],
                 query=sql,
                 context_information=context_information,
+                op_tag=edit_tag,
             )
             cur.close()
         return None
@@ -1119,12 +1239,14 @@ def alter_table_drop_columns(
     try:
         connection_manager: SFConnectionManager = SFConnectionManager.get_instance()
         table = quote_identifier(context_information["table_name"])
+        edit_tag = _edit_op_tag(context_information)
         for col_name in column_names:
             sql = f"ALTER TABLE {table} DROP COLUMN {quote_identifier(col_name)}"
             cur = connection_manager.execute_query(
                 connection_name=context_information["connection_name"],
                 query=sql,
                 context_information=context_information,
+                op_tag=edit_tag,
             )
             cur.close()
         return None

--- a/helpers/expression_compiler.py
+++ b/helpers/expression_compiler.py
@@ -1,0 +1,70 @@
+"""Safe QGIS-expression -> Snowflake SQL compilation.
+
+QGIS feature requests (filter expressions) and layer subset strings can carry
+attacker-influenceable predicates that QGIS persists verbatim inside .qgs/.qgz
+project files. Concatenating that text straight into SQL is a SQL-injection sink
+(SNOW-3712078 / SNOW-3712093).
+
+Instead of trusting the text, we compile it through ``QgsSqlExpressionCompiler``,
+which only emits SQL for a known set of operators/functions and routes every
+identifier and literal through our quoting helpers. Anything that does not
+compile *completely* is refused, so raw predicate text is never pushed down to
+Snowflake; the caller falls back to client-side filtering (or rejects the
+subset string).
+"""
+
+from typing import Optional
+
+from qgis.core import QgsExpression, QgsFields, QgsSqlExpressionCompiler
+
+from .sql import quote_identifier, quote_literal
+
+
+class SFExpressionCompiler(QgsSqlExpressionCompiler):
+    """QgsSqlExpressionCompiler that quotes for Snowflake via the central
+    helpers (so identifiers and string literals are backslash/quote safe)."""
+
+    def __init__(self, fields: QgsFields):
+        super().__init__(
+            fields,
+            QgsSqlExpressionCompiler.Flags(),
+            False,
+        )
+
+    def quotedIdentifier(self, identifier: str) -> str:
+        return quote_identifier(identifier)
+
+    def quotedValue(self, value, ok):
+        # The C++ signature passes ``ok`` by reference; the PyQGIS override
+        # returns a ``(sql, ok)`` tuple instead.
+        if value is None:
+            return "NULL", True
+        if isinstance(value, bool):
+            return ("TRUE" if value else "FALSE"), True
+        if isinstance(value, (int, float)):
+            return str(value), True
+        return quote_literal(str(value)), True
+
+
+def compile_expression_to_sql(
+    expression_text: str, fields: QgsFields
+) -> Optional[str]:
+    """Return safe Snowflake SQL for ``expression_text``, or ``None`` if it
+    cannot be fully and safely compiled.
+
+    ``None`` means the caller MUST NOT push the predicate down (filter
+    client-side or reject it); it must never fall back to using the raw text.
+    """
+    if not expression_text or fields is None:
+        return None
+    try:
+        expression = QgsExpression(expression_text)
+        if expression.hasParserError():
+            return None
+        compiler = SFExpressionCompiler(fields)
+        if compiler.compile(expression) == QgsSqlExpressionCompiler.Complete:
+            compiled = compiler.result()
+            return compiled or None
+    except Exception:
+        return None
+    return None

--- a/helpers/expression_compiler.py
+++ b/helpers/expression_compiler.py
@@ -5,45 +5,153 @@ attacker-influenceable predicates that QGIS persists verbatim inside .qgs/.qgz
 project files. Concatenating that text straight into SQL is a SQL-injection sink
 (SNOW-3712078 / SNOW-3712093).
 
-Instead of trusting the text, we compile it through ``QgsSqlExpressionCompiler``,
-which only emits SQL for a known set of operators/functions and routes every
-identifier and literal through our quoting helpers. Anything that does not
-compile *completely* is refused, so raw predicate text is never pushed down to
+Instead of trusting the text, we parse it with ``QgsExpression`` and walk the
+resulting AST ourselves, emitting Snowflake SQL only for a small whitelist of
+node types and operators and routing every identifier and literal through our
+quoting helpers. Anything outside that whitelist makes the whole compilation
+fail (returns ``None``), so raw predicate text is never pushed down to
 Snowflake; the caller falls back to client-side filtering (or rejects the
 subset string).
+
+Note: QGIS' own C++ SQL expression compiler is deliberately *not* exposed in
+the Python bindings, so we cannot subclass it; the ``QgsExpression`` AST node
+API used here is the supported PyQGIS surface.
 """
 
 from typing import Optional
 
-from qgis.core import QgsExpression, QgsFields, QgsSqlExpressionCompiler
+from qgis.core import (
+    QgsExpression,
+    QgsExpressionNodeBinaryOperator,
+    QgsExpressionNodeColumnRef,
+    QgsExpressionNodeInOperator,
+    QgsExpressionNodeLiteral,
+    QgsExpressionNodeUnaryOperator,
+    QgsFields,
+)
 
 from .sql import quote_identifier, quote_literal
 
 
-class SFExpressionCompiler(QgsSqlExpressionCompiler):
-    """QgsSqlExpressionCompiler that quotes for Snowflake via the central
-    helpers (so identifiers and string literals are backslash/quote safe)."""
+def _resolve_enum(owner, nested_name: str, member: str):
+    """Resolve an enum member that may be exposed unscoped on ``owner`` or
+    scoped under ``owner.<nested_name>`` depending on the PyQGIS build."""
+    if hasattr(owner, member):
+        return getattr(owner, member)
+    nested = getattr(owner, nested_name, None)
+    if nested is not None and hasattr(nested, member):
+        return getattr(nested, member)
+    return None
 
-    def __init__(self, fields: QgsFields):
-        super().__init__(
-            fields,
-            QgsSqlExpressionCompiler.Flags(),
-            False,
-        )
 
-    def quotedIdentifier(self, identifier: str) -> str:
-        return quote_identifier(identifier)
+# Map the safe subset of QGIS binary operators to their Snowflake SQL spelling.
+# Arithmetic / concat / regexp / power / integer-div are intentionally omitted
+# so only boolean predicates ever compile.
+_BINARY_SQL = {}
+for _member, _sql in (
+    ("boEQ", "="),
+    ("boNE", "<>"),
+    ("boLE", "<="),
+    ("boGE", ">="),
+    ("boLT", "<"),
+    ("boGT", ">"),
+    ("boAnd", "AND"),
+    ("boOr", "OR"),
+    ("boLike", "LIKE"),
+    ("boILike", "ILIKE"),
+    ("boNotLike", "NOT LIKE"),
+    ("boNotILike", "NOT ILIKE"),
+    ("boIs", "IS"),
+    ("boIsNot", "IS NOT"),
+):
+    _key = _resolve_enum(QgsExpressionNodeBinaryOperator, "BinaryOperator", _member)
+    if _key is not None:
+        _BINARY_SQL[_key] = _sql
 
-    def quotedValue(self, value, ok):
-        # The C++ signature passes ``ok`` by reference; the PyQGIS override
-        # returns a ``(sql, ok)`` tuple instead.
-        if value is None:
-            return "NULL", True
-        if isinstance(value, bool):
-            return ("TRUE" if value else "FALSE"), True
-        if isinstance(value, (int, float)):
-            return str(value), True
-        return quote_literal(str(value)), True
+_UO_NOT = _resolve_enum(QgsExpressionNodeUnaryOperator, "UnaryOperator", "uoNot")
+
+
+def _compile_column(node, fields: QgsFields) -> Optional[str]:
+    if fields is None:
+        return None
+    idx = fields.lookupField(node.name())
+    if idx < 0:
+        return None
+    # Emit the canonical field name from the layer, not the raw reference.
+    return quote_identifier(fields.at(idx).name())
+
+
+def _compile_literal(node) -> Optional[str]:
+    value = node.value()
+    if value is None:
+        return "NULL"
+    # bool must be checked before int (bool is a subclass of int).
+    if isinstance(value, bool):
+        return "TRUE" if value else "FALSE"
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, float):
+        return str(value)
+    if isinstance(value, str):
+        return quote_literal(value)
+    return None
+
+
+def _compile_unary(node, fields: QgsFields) -> Optional[str]:
+    if _UO_NOT is None or node.op() != _UO_NOT:
+        return None
+    operand = _compile_node(node.operand(), fields)
+    if operand is None:
+        return None
+    return f"(NOT {operand})"
+
+
+def _compile_binary(node, fields: QgsFields) -> Optional[str]:
+    sql_op = _BINARY_SQL.get(node.op())
+    if sql_op is None:
+        return None
+    left = _compile_node(node.opLeft(), fields)
+    right = _compile_node(node.opRight(), fields)
+    if left is None or right is None:
+        return None
+    return f"({left} {sql_op} {right})"
+
+
+def _compile_in(node, fields: QgsFields) -> Optional[str]:
+    left = _compile_node(node.node(), fields)
+    if left is None:
+        return None
+    node_list = node.list()
+    if node_list is None:
+        return None
+    members = node_list.list()
+    if not members:
+        return None
+    compiled_members = []
+    for member in members:
+        compiled = _compile_node(member, fields)
+        if compiled is None:
+            return None
+        compiled_members.append(compiled)
+    keyword = "NOT IN" if node.isNotIn() else "IN"
+    return f"({left} {keyword} ({', '.join(compiled_members)}))"
+
+
+def _compile_node(node, fields: QgsFields) -> Optional[str]:
+    if node is None:
+        return None
+    if isinstance(node, QgsExpressionNodeColumnRef):
+        return _compile_column(node, fields)
+    if isinstance(node, QgsExpressionNodeLiteral):
+        return _compile_literal(node)
+    if isinstance(node, QgsExpressionNodeUnaryOperator):
+        return _compile_unary(node, fields)
+    if isinstance(node, QgsExpressionNodeBinaryOperator):
+        return _compile_binary(node, fields)
+    if isinstance(node, QgsExpressionNodeInOperator):
+        return _compile_in(node, fields)
+    # Functions, CASE/condition, BETWEEN, index operators, etc. are refused.
+    return None
 
 
 def compile_expression_to_sql(
@@ -61,10 +169,9 @@ def compile_expression_to_sql(
         expression = QgsExpression(expression_text)
         if expression.hasParserError():
             return None
-        compiler = SFExpressionCompiler(fields)
-        if compiler.compile(expression) == QgsSqlExpressionCompiler.Complete:
-            compiled = compiler.result()
-            return compiled or None
+        root = expression.rootNode()
+        if root is None:
+            return None
+        return _compile_node(root, fields) or None
     except Exception:
         return None
-    return None

--- a/helpers/layer_creation.py
+++ b/helpers/layer_creation.py
@@ -1,5 +1,6 @@
 import typing
 from ..providers.sf_data_source_provider import SFDataProvider
+from ..helpers.sql import qualified_table_name, quote_identifier
 from qgis.core import (
     QgsFeature,
     QgsField,
@@ -255,7 +256,10 @@ def check_table_exceeds_size(
     data_base_name = table_information["database"]
     schema_name = table_information["schema"]
     table_name = table_information["table"]
-    qre = f'SELECT count(*) FROM "{data_base_name}"."{schema_name}"."{table_name}"'
+    qre = (
+        f"SELECT count(*) FROM "  # nosec B608 - identifiers escaped via qualified_table_name
+        f"{qualified_table_name(data_base_name, schema_name, table_name)}"
+    )
     cur_count = sf_data_provider.execute_query(
         query=qre,
         connection_name=connection_name,
@@ -309,7 +313,10 @@ def get_srid_from_table(
     data_base_name = table_information["database"]
     schema_name = table_information["schema"]
     table_name = table_information["table"]
-    qre = f'SELECT ANY_VALUE(ST_SRID("{column_name}")) FROM "{data_base_name}"."{schema_name}"."{table_name}"'
+    qre = (
+        f"SELECT ANY_VALUE(ST_SRID({quote_identifier(column_name)})) "  # nosec B608 - identifiers escaped via quote_identifier/qualified_table_name
+        f"FROM {qualified_table_name(data_base_name, schema_name, table_name)}"
+    )
     cur_srid = sf_data_provider.execute_query(
         query=qre,
         connection_name=connection_name,

--- a/helpers/layer_creation.py
+++ b/helpers/layer_creation.py
@@ -1,6 +1,7 @@
 import typing
 from ..providers.sf_data_source_provider import SFDataProvider
 from ..helpers.sql import qualified_table_name, quote_identifier
+from ..helpers.mappings import create_qgs_field
 from qgis.core import (
     QgsFeature,
     QgsField,
@@ -218,7 +219,11 @@ def add_features_attributes_to_layer(
         if layer_field.name() == geo_column_name:
             continue
         layer_fields.append(
-            QgsField(layer_field.name(), QMetaType.Type.QString, subType=layer_field.subType())
+            create_qgs_field(
+                layer_field.name(),
+                QMetaType.Type.QString,
+                sub_type=layer_field.subType(),
+            )
         )
 
     for layer_type in layer_dict:

--- a/helpers/mappings.py
+++ b/helpers/mappings.py
@@ -1,7 +1,26 @@
-from qgis.core import QgsWkbTypes
+from qgis.core import Qgis, QgsField, QgsWkbTypes
 from qgis.PyQt.QtCore import (QVariant,QMetaType)
 
 from ..enums.snowflake_metadata_type import SnowflakeMetadataType
+
+
+def create_qgs_field(name, metatype, type_name="", sub_type=None):
+    """Construct a QgsField in a QGIS-version-compatible way.
+
+    QGIS >= 3.38 accepts a QMetaType.Type argument; older builds (e.g. QGIS
+    3.34 on Qt5) only accept the deprecated QVariant.Type overload. QVariant.Type
+    and QMetaType.Type share the same integer values for the types used here, so
+    converting via int() is safe.
+    """
+    if Qgis.QGIS_VERSION_INT >= 33800:
+        field = QgsField(name, metatype, type_name)
+        if sub_type is not None:
+            field.setSubType(sub_type)
+        return field
+    field = QgsField(name, QVariant.Type(int(metatype)), type_name)
+    if sub_type is not None:
+        field.setSubType(QVariant.Type(int(sub_type)))
+    return field
 
 
 mapping_single_to_multi_geometry_type = {

--- a/helpers/sql.py
+++ b/helpers/sql.py
@@ -5,14 +5,29 @@ import re
 _SIMPLE_IDENT = re.compile(r'^[A-Za-z_][A-Za-z0-9_$]*$')
 
 
+def _is_wellformed_quoted_identifier(name: str) -> bool:
+    """True only when ``name`` is a single, correctly-quoted Snowflake
+    identifier: it is wrapped in double quotes and every interior double quote
+    is doubled (escaped).  A value like ``"a""b"`` is well-formed; a value like
+    ``"x" AS SELECT ...--"`` is not, because it carries un-doubled interior
+    quotes that would break out of the identifier context.
+    """
+    if len(name) < 2 or not name.startswith('"') or not name.endswith('"'):
+        return False
+    return '"' not in name[1:-1].replace('""', "")
+
+
 def quote_identifier(name: str) -> str:
     """Quote a Snowflake identifier only when necessary.
 
     Simple identifiers (letters, digits, underscores) are left unquoted so
-    Snowflake applies its default uppercasing.  Names that contain spaces,
-    special characters, or are already double-quoted are wrapped/preserved.
+    Snowflake applies its default uppercasing.  A value that is already a
+    single well-formed quoted identifier is preserved; anything else — including
+    strings that merely start and end with a double quote but hide un-doubled
+    interior quotes — is fully re-escaped so it cannot break out of the
+    identifier context (SNOW-3712084).
     """
-    if name.startswith('"') and name.endswith('"'):
+    if _is_wellformed_quoted_identifier(name):
         return name
     if _SIMPLE_IDENT.match(name):
         return name
@@ -22,9 +37,14 @@ def quote_identifier(name: str) -> str:
 def quote_literal(value: str) -> str:
     """Escape a string literal for use in SQL WHERE/ILIKE clauses.
 
-    Wraps in single quotes and escapes internal single quotes.
+    Snowflake single-quoted string constants treat the backslash as an escape
+    character, so ``\\'`` is parsed as a literal apostrophe rather than a
+    backslash followed by a quote.  Doubling single quotes alone is therefore
+    insufficient: a value ending in a backslash would let an attacker break out
+    of the literal (SNOW-3712090 / SNOW-3712092).  Escape backslashes first,
+    then single quotes.
     """
-    return "'" + value.replace("'", "''") + "'"
+    return "'" + value.replace("\\", "\\\\").replace("'", "''") + "'"
 
 
 def quote_json_literal_for_parse_json(value: str) -> str:
@@ -42,3 +62,26 @@ def quote_json_literal_for_parse_json(value: str) -> str:
 def qualified_table_name(database: str, schema: str, table: str) -> str:
     """Return a fully qualified and quoted Snowflake table reference."""
     return f"{quote_identifier(database)}.{quote_identifier(schema)}.{quote_identifier(table)}"
+
+
+_SQL_STATEMENT_BREAKERS = re.compile(
+    r"--|/\*|\*/|;|\bUNION\b|\bINTERSECT\b|\bEXCEPT\b|\bMINUS\b",
+    re.IGNORECASE,
+)
+
+
+def predicate_has_statement_breakers(predicate: str) -> bool:
+    """Heuristic guard for a free-text SQL predicate (e.g. a Processing
+    WHERE-clause parameter).
+
+    Returns True when the text contains tokens that could terminate the
+    statement (``;``), start a comment (``--`` / ``/* */``) to swallow the rest
+    of the query, or splice in a set operation (``UNION`` / ``INTERSECT`` /
+    ``EXCEPT`` / ``MINUS``) used for cross-table exfiltration (SNOW-3712086).
+    This is an intentionally conservative blocklist for the one place that must
+    accept raw SQL from the user; identifier/literal inputs use the quoting
+    helpers instead.
+    """
+    if not predicate:
+        return False
+    return bool(_SQL_STATEMENT_BREAKERS.search(predicate))

--- a/helpers/utils.py
+++ b/helpers/utils.py
@@ -484,8 +484,10 @@ def get_or_create_connection_authcfg(connection_name: str):
 
         auth_manager = QgsApplication.authManager()
         if existing:
-            probe = QgsAuthMethodConfig()
-            auth_manager.loadAuthenticationConfig(existing, probe, False)
+            # full=True so the encrypted config map (connection_name) is
+            # actually loaded; otherwise probe.config(...) is empty and we would
+            # never reuse the stored id, leaking a new auth config every call.
+            probe = get_auth_method_config(existing)
             if probe.isValid() and probe.config("connection_name") == connection_name:
                 return existing
 

--- a/helpers/utils.py
+++ b/helpers/utils.py
@@ -216,7 +216,13 @@ def set_connection_settings(connection_settings: dict) -> None:
     if "role" in connection_settings:
         settings.setValue("role", connection_settings["role"])
     if connection_settings["connection_type"] == "Default Authentication":
-        settings.setValue("password", connection_settings["password"])
+        # SNOW-3712079: when the encrypted (Configurations) tab is used no
+        # plaintext password is provided; make sure any previously stored
+        # cleartext password is removed rather than left behind in the INI.
+        if connection_settings.get("password"):
+            settings.setValue("password", connection_settings["password"])
+        else:
+            settings.remove("password")
     if connection_settings["connection_type"] == "Key Pair":
         settings.setValue(
             "private_key_file", connection_settings.get("private_key_file", "")
@@ -376,6 +382,7 @@ def decodeUri(uri: str) -> Dict[str, str]:
     """
     supported_keys = [
         "connection_name",
+        "authcfg",
         "sql_query",
         "schema_name",
         "table_name",
@@ -392,6 +399,13 @@ def decodeUri(uri: str) -> Dict[str, str]:
         flags=re.DOTALL,
     )
     params = {key: value for key, value in matches}
+    # SNOW-3712094: an authcfg= token is the redacted form of connection_name=.
+    # Resolve it back to the alias for internal use; the alias is authoritative
+    # so a stale connection_name= left in a hand-edited URI cannot override it.
+    if params.get("authcfg"):
+        resolved = resolve_authcfg_connection_name(params["authcfg"])
+        if resolved:
+            params["connection_name"] = resolved
     return params
 
 
@@ -444,6 +458,85 @@ def get_auth_method_config(config_id: str) -> QgsAuthMethodConfig:
     return method_config
 
 
+# --- SNOW-3712094: keep the connection alias out of persisted layer URIs -----
+# The layer datasource URI is stored verbatim inside .qgs/.qgz/.qlr files. To
+# avoid leaking the local connection alias (which enables a targeted
+# confused-deputy on project open) we hide it behind a QGIS auth-config id.
+# The auth DB is per-machine, so the id is meaningless on any other machine.
+_LAYER_AUTHCFG_MAP_KEY = "layer_authcfg"
+
+
+def get_or_create_connection_authcfg(connection_name: str):
+    """Return a QGIS auth-config id whose config-map hides ``connection_name``.
+
+    Reuses a previously created id (persisted under the connection's settings
+    group) when possible. Returns ``None`` on any failure so callers can fall
+    back to the legacy ``connection_name=`` token without breaking layer
+    creation.
+    """
+    if not connection_name:
+        return None
+    try:
+        settings = get_qsettings()
+        settings.beginGroup(f"connections/{connection_name}")
+        existing = settings.value(_LAYER_AUTHCFG_MAP_KEY, defaultValue="")
+        settings.endGroup()
+
+        auth_manager = QgsApplication.authManager()
+        if existing:
+            probe = QgsAuthMethodConfig()
+            auth_manager.loadAuthenticationConfig(existing, probe, False)
+            if probe.isValid() and probe.config("connection_name") == connection_name:
+                return existing
+
+        method_config = QgsAuthMethodConfig()
+        method_config.setName(f"snowflakedb layer: {connection_name}")
+        method_config.setMethod("Basic")
+        method_config.setConfig("connection_name", connection_name)
+        if not auth_manager.storeAuthenticationConfig(method_config):
+            return None
+        config_id = method_config.id()
+        if not config_id:
+            return None
+
+        settings.beginGroup(f"connections/{connection_name}")
+        settings.setValue(_LAYER_AUTHCFG_MAP_KEY, config_id)
+        settings.endGroup()
+        settings.sync()
+        return config_id
+    except Exception:
+        return None
+
+
+def resolve_authcfg_connection_name(config_id: str):
+    """Recover the connection alias hidden behind an auth-config id.
+
+    Returns ``None`` when the id does not resolve (e.g. project opened on a
+    different machine), which correctly prevents silent auto-connection.
+    """
+    if not config_id:
+        return None
+    try:
+        method_config = get_auth_method_config(config_id)
+        if not method_config.isValid():
+            return None
+        return method_config.config("connection_name") or None
+    except Exception:
+        return None
+
+
+def connection_uri_token(connection_name: str) -> str:
+    """Return the connection token to embed in a persisted layer URI.
+
+    Prefers the redacted ``authcfg=<id>`` form; falls back to the legacy
+    ``connection_name=<alias>`` form when an auth config cannot be created.
+    """
+    config_id = get_or_create_connection_authcfg(connection_name)
+    if config_id:
+        return f"authcfg={config_id}"
+    return f"connection_name={connection_name}"
+
+
 def prompt_and_get_primary_key(context_information: dict, data_type: str) -> str:
     """Prompts the user to select a primary key for a table.
 
@@ -467,11 +560,32 @@ def prompt_and_get_primary_key(context_information: dict, data_type: str) -> str
         The name of the column selected as the primary key, or an empty
         string if no primary key is selected or the process is skipped.
     """
-    from ..helpers.data_base import get_table_columns, check_column_has_duplicates
+    from ..helpers.data_base import (
+        check_column_has_duplicates,
+        get_declared_primary_key,
+        get_table_columns,
+    )
     from ..helpers.messages import get_set_primary_key_message_box
 
     primary_key = ""
     if data_type not in ["H3GEO", "H3"]:
+        # C4: if the table has a single-column PK declared in Snowflake,
+        # use it directly instead of prompting. Composite PKs and tables
+        # with no PK still fall through to the interactive dialog.
+        # Snowflake PKs are informational (not enforced), so verify there
+        # are no duplicate values before silently auto-selecting; otherwise
+        # fall through so the user sees the duplicate warning dialog.
+        declared = get_declared_primary_key(context_information)
+        if declared:
+            try:
+                declared_has_dupes = check_column_has_duplicates(
+                    context_information, declared
+                )
+            except Exception:
+                declared_has_dupes = True
+            if not declared_has_dupes:
+                return declared
+
         message_box_accept, primary_key_selected = get_set_primary_key_message_box(
             "Set Primary Key",
             (

--- a/managers/sf_connection_manager.py
+++ b/managers/sf_connection_manager.py
@@ -1,4 +1,7 @@
-from typing import Dict
+from collections import defaultdict
+from typing import Dict, List, Optional
+import json
+import threading
 import typing
 import snowflake.connector
 
@@ -6,6 +9,31 @@ from qgis.core import Qgis, QgsMessageLog
 
 from ..helpers.utils import get_auth_information
 from ..helpers.sql import quote_identifier
+
+
+_BASE_QUERY_TAG = "qgis-snowflake-connector"
+
+
+def build_op_tag(
+    op: str,
+    connection_name: typing.Optional[str] = None,
+    schema: typing.Optional[str] = None,
+    table: typing.Optional[str] = None,
+) -> str:
+    """Build a JSON-encoded QUERY_TAG payload for cost attribution.
+
+    The resulting string is set as the Snowflake session QUERY_TAG so that
+    ACCOUNT_USAGE.QUERY_HISTORY rows issued by the plugin can be filtered by
+    operation type and target layer.
+    """
+    payload = {"app": _BASE_QUERY_TAG, "op": op}
+    if connection_name:
+        payload["conn"] = connection_name
+    if schema and table:
+        payload["layer"] = f"{schema}.{table}"
+    elif table:
+        payload["layer"] = table
+    return json.dumps(payload, separators=(",", ":"))
 
 
 class SFConnectionManager:
@@ -27,6 +55,18 @@ class SFConnectionManager:
         Initializes the SFConnectionManager object.
         """
         self.opened_connections: Dict[str, snowflake.connector.SnowflakeConnection] = {}
+        # A6: track the most recently-set active schema per connection so we
+        # can skip redundant `USE SCHEMA` round-trips on every execute_query.
+        self._active_schemas: Dict[str, str] = {}
+        # E3: track the most recently-set QUERY_TAG per connection so we only
+        # issue `ALTER SESSION SET QUERY_TAG` when the requested tag changes.
+        self._active_query_tags: Dict[str, str] = {}
+        # A9: track cursors currently executing, keyed by the thread that
+        # owns them, so tasks can cancel their own queries on task.cancel()
+        # without touching cursors running on other threads (e.g. the main
+        # thread's feature iterator).
+        self._active_cursors: Dict[int, List[snowflake.connector.cursor.SnowflakeCursor]] = defaultdict(list)
+        self._lock = threading.Lock()
 
     def create_snowflake_connection(
         self, conn_params: dict
@@ -64,7 +104,7 @@ class SFConnectionManager:
                 "login_timeout": 5,
                 "client_session_keep_alive": True,
                 "session_parameters": {
-                    "QUERY_TAG": "qgis-snowflake-connector",
+                    "QUERY_TAG": _BASE_QUERY_TAG,
                 },
             }
 
@@ -89,9 +129,15 @@ class SFConnectionManager:
             self.opened_connections[connection_name] = self.create_snowflake_connection(
                 conn_params
             )
+            # Fresh session: forget whatever schema / query tag we thought was
+            # active on the previous socket.
+            self._active_schemas.pop(connection_name, None)
+            self._active_query_tags[connection_name] = _BASE_QUERY_TAG
         except Exception as e:
             if connection_name in self.opened_connections:
                 del self.opened_connections[connection_name]
+            self._active_schemas.pop(connection_name, None)
+            self._active_query_tags.pop(connection_name, None)
             raise e
 
     def get_connection(
@@ -128,6 +174,8 @@ class SFConnectionManager:
                 connection = self.opened_connections[connection_name]
                 connection.close()
                 del connection
+            self._active_schemas.pop(connection_name, None)
+            self._active_query_tags.pop(connection_name, None)
         except Exception as e:
             raise e
 
@@ -157,11 +205,116 @@ class SFConnectionManager:
         except Exception as e:
             raise e
 
+    def _apply_schema_if_changed(
+        self,
+        cursor: snowflake.connector.cursor.SnowflakeCursor,
+        connection_name: str,
+        schema_name: Optional[str],
+    ) -> None:
+        """Issue `USE SCHEMA` only when the target differs from the cached
+        active schema for this connection (A6).
+        """
+        if not schema_name:
+            return
+        active = self._active_schemas.get(connection_name)
+        if active == schema_name:
+            return
+        cursor.execute(f'USE SCHEMA {quote_identifier(schema_name)}')
+        self._active_schemas[connection_name] = schema_name
+
+    def _apply_query_tag_if_changed(
+        self,
+        cursor: snowflake.connector.cursor.SnowflakeCursor,
+        connection_name: str,
+        op_tag: Optional[str],
+    ) -> None:
+        """Issue `ALTER SESSION SET QUERY_TAG` only when the tag changes (E3).
+
+        ``op_tag=None`` means "no operation-specific tag", which we map to the
+        base plugin tag so untagged queries don't inherit whatever operation
+        tag the previous query set on the session.
+        """
+        effective = op_tag or _BASE_QUERY_TAG
+        active = self._active_query_tags.get(connection_name)
+        if active == effective:
+            return
+        # effective is either the base tag constant or a build_op_tag() JSON
+        # payload of short string fields, so the only character we need to
+        # escape for a Snowflake string literal is the single quote.
+        escaped = effective.replace("'", "''")
+        cursor.execute(f"ALTER SESSION SET QUERY_TAG = '{escaped}'")
+        self._active_query_tags[connection_name] = effective
+
+    def _register_cursor(
+        self, cursor: snowflake.connector.cursor.SnowflakeCursor
+    ) -> int:
+        tid = threading.get_ident()
+        with self._lock:
+            self._active_cursors[tid].append(cursor)
+        return tid
+
+    def _unregister_cursor(
+        self,
+        tid: int,
+        cursor: snowflake.connector.cursor.SnowflakeCursor,
+    ) -> None:
+        with self._lock:
+            lst = self._active_cursors.get(tid)
+            if not lst:
+                return
+            try:
+                lst.remove(cursor)
+            except ValueError:
+                pass
+            if not lst:
+                self._active_cursors.pop(tid, None)
+
+    def _wire_close_to_unregister(
+        self,
+        cursor: snowflake.connector.cursor.SnowflakeCursor,
+        tid: int,
+    ) -> None:
+        """Unregister the cursor when the caller closes it, so it remains
+        cancellable across the whole fetch lifetime instead of only during
+        ``cursor.execute()`` (A9).
+        """
+        _orig_close = cursor.close
+
+        def _close_and_unregister(*args, **kwargs):
+            self._unregister_cursor(tid, cursor)
+            return _orig_close(*args, **kwargs)
+
+        cursor.close = _close_and_unregister
+
+    def cancel_pending_on_thread(self, thread_id: int) -> int:
+        """Cancel every Snowflake query currently executing on `thread_id`.
+
+        Called from another thread (typically the main UI thread when the
+        user hits Cancel on a QgsTask running on a worker thread).
+
+        Returns the number of cursors whose `cancel()` was invoked.
+        """
+        with self._lock:
+            cursors = list(self._active_cursors.get(thread_id, ()))
+        cancelled = 0
+        for cursor in cursors:
+            try:
+                cursor.cancel()
+                cancelled += 1
+            except Exception as e:
+                QgsMessageLog.logMessage(
+                    f"cursor.cancel() failed: {e}",
+                    "Snowflake Plugin",
+                    Qgis.MessageLevel.Warning,
+                )
+        return cancelled
+
     def execute_query(
         self,
         connection_name: str,
         query: str,
         context_information: Dict[str, typing.Union[str, None]] = None,
+        op_tag: Optional[str] = None,
     ) -> snowflake.connector.cursor.SnowflakeCursor:
         """
         Executes the given query on the specified connection.
@@ -169,6 +322,9 @@ class SFConnectionManager:
         Args:
             connection_name (str): The name of the connection to use.
             query (str): The SQL query to execute.
+            op_tag (str, optional): A QUERY_TAG value (built via
+                ``build_op_tag``) for Snowflake cost attribution. Only applied
+                when different from the tag cached for this connection.
 
         Returns:
             snowflake.connector.cursor.SnowflakeCursor: The cursor object used to execute the query.
@@ -176,17 +332,17 @@ class SFConnectionManager:
         Raises:
             Exception: If an error occurs while executing the query.
         """
+        cursor = self.create_cursor(connection_name)
+        schema_name = None
+        if context_information is not None:
+            schema_name = context_information.get("schema_name")
+        tid = self._register_cursor(cursor)
         try:
-            cursor = self.create_cursor(connection_name)
-            if context_information is not None:
-                if (
-                    "schema_name" in context_information
-                    and context_information["schema_name"] is not None
-                ):
-                    cursor.execute(f'USE SCHEMA {quote_identifier(context_information["schema_name"])}')
+            self._apply_schema_if_changed(cursor, connection_name, schema_name)
+            self._apply_query_tag_if_changed(cursor, connection_name, op_tag)
             cursor.execute(query)
-            return cursor
         except Exception as e:
+            self._unregister_cursor(tid, cursor)
             QgsMessageLog.logMessage(
                 f"execute_query failed: {e}\n"
                 f"Query (first 2000 chars): {query[:2000]}",
@@ -194,6 +350,8 @@ class SFConnectionManager:
                 Qgis.MessageLevel.Critical,
             )
             raise e
+        self._wire_close_to_unregister(cursor, tid)
+        return cursor
 
     def execute_query_with_params(
         self,
@@ -201,6 +359,7 @@ class SFConnectionManager:
         query: str,
         params: Dict[str, typing.Union[str, None]] = None,
         context_information: Dict[str, typing.Union[str, None]] = None,
+        op_tag: Optional[str] = None,
     ) -> snowflake.connector.cursor.SnowflakeCursor:
         """Executes a SQL query with parameters on a specified Snowflake connection.
 
@@ -227,20 +386,20 @@ class SFConnectionManager:
             Exception: Propagates any exception raised by the underlying
                 Snowflake connector during cursor creation or query execution.
         """
+        cursor = self.create_cursor(connection_name)
+        schema_name = None
+        if context_information is not None:
+            schema_name = context_information.get("schema_name")
+        tid = self._register_cursor(cursor)
         try:
-            cursor = self.create_cursor(connection_name)
-            if context_information is not None:
-                if (
-                    "schema_name" in context_information
-                    and context_information["schema_name"] is not None
-                ):
-                    cursor.execute(f'USE SCHEMA {quote_identifier(context_information["schema_name"])}')
-
+            self._apply_schema_if_changed(cursor, connection_name, schema_name)
+            self._apply_query_tag_if_changed(cursor, connection_name, op_tag)
             cursor.execute(query, params=params)
-
-            return cursor
         except Exception as e:
+            self._unregister_cursor(tid, cursor)
             raise e
+        self._wire_close_to_unregister(cursor, tid)
+        return cursor
 
     def reconnect(self, connection_name: str) -> None:
         """

--- a/metadata.txt
+++ b/metadata.txt
@@ -8,7 +8,7 @@ qgisMinimumVersion=3.34.1
 qgisMaximumVersion=4.99
 supportsQt6=True
 description=This package includes the Snowflake Connector for QGIS.
-version=1.0.10
+version=1.0.11
 author=Snowflake Inc.
 email=erick.cuberojimenez@snowflake.com
 
@@ -21,7 +21,15 @@ repository=https://github.com/snowflakedb/qgis-snowflake-connector/
 # Recommended items:
 
 hasProcessingProvider=yes
-changelog=1.0.10 - Refresh attribute table after edits without reopening the layer;
+changelog=1.0.11 - Security hardening for QGIS plugin portal scan:
+ route all remaining raw identifier interpolation in helpers/layer_creation.py
+ and tasks/sf_connect_task.py through quote_identifier / quote_literal /
+ qualified_table_name; validate URL scheme and host before the GitHub update
+ check in qgis_snowflake_connector.py; replace silent exception swallowing in
+ the feature iterator and export algorithm with QgsMessageLog diagnostics;
+ annotate already-sanitized SQL construction sites with documented bandit
+ suppressions. No user-visible behaviour change.
+ 1.0.10 - Refresh attribute table after edits without reopening the layer;
  advertise auto-increment default for numeric primary keys via defaultValueClause();
  add "Load all rows" option for tables exceeding the 50,000-row visualization limit.
 

--- a/metadata.txt
+++ b/metadata.txt
@@ -8,7 +8,7 @@ qgisMinimumVersion=3.34.1
 qgisMaximumVersion=4.99
 supportsQt6=True
 description=This package includes the Snowflake Connector for QGIS.
-version=1.0.11
+version=1.0.13
 author=Snowflake Inc.
 email=erick.cuberojimenez@snowflake.com
 
@@ -21,7 +21,15 @@ repository=https://github.com/snowflakedb/qgis-snowflake-connector/
 # Recommended items:
 
 hasProcessingProvider=yes
-changelog=1.0.11 - Security hardening for QGIS plugin portal scan:
+changelog=1.0.13 - Fix SNOW-3712094 auth-config reuse: load the stored config
+ with full=True so the connection alias is matched and the existing authcfg id
+ is reused, instead of leaking a new QGIS auth config on every layer creation.
+ 1.0.12 - Fix plugin load failure ("cannot import name
+ 'QgsSqlExpressionCompiler' from 'qgis.core'"): reimplement the filter/subset
+ expression compiler as a pure-Python QgsExpression AST walker, since
+ QgsSqlExpressionCompiler is not exposed in the PyQGIS bindings. Injection
+ protection and fail-safe fallback behaviour are preserved.
+ 1.0.11 - Security hardening for QGIS plugin portal scan:
  route all remaining raw identifier interpolation in helpers/layer_creation.py
  and tasks/sf_connect_task.py through quote_identifier / quote_literal /
  qualified_table_name; validate URL scheme and host before the GitHub update

--- a/processing/buffer_table.py
+++ b/processing/buffer_table.py
@@ -114,7 +114,7 @@ class BufferTableAlgorithm(QgsProcessingAlgorithm):
         if not overwrite:
             exists_cursor = mgr.execute_query(
                 connection_name,
-                f"SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES "
+                f"SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES "  # nosec B608 - values escaped via quote_literal
                 f"WHERE TABLE_SCHEMA ILIKE {quote_literal(schema)} "
                 f"AND TABLE_NAME ILIKE {quote_literal(output)}",
                 ctx,
@@ -130,7 +130,7 @@ class BufferTableAlgorithm(QgsProcessingAlgorithm):
 
         type_cursor = mgr.execute_query(
             connection_name,
-            f"SELECT DATA_TYPE FROM INFORMATION_SCHEMA.COLUMNS "
+            f"SELECT DATA_TYPE FROM INFORMATION_SCHEMA.COLUMNS "  # nosec B608 - values escaped via quote_literal
             f"WHERE TABLE_SCHEMA ILIKE {quote_literal(schema)} "
             f"AND TABLE_NAME ILIKE {quote_literal(table)} "
             f"AND COLUMN_NAME ILIKE {quote_literal(geo_col)}",
@@ -152,7 +152,7 @@ class BufferTableAlgorithm(QgsProcessingAlgorithm):
 
         create_verb = "CREATE OR REPLACE TABLE" if overwrite else "CREATE TABLE"
         sql = (
-            f"{create_verb} {qs}.{qo} AS "
+            f"{create_verb} {qs}.{qo} AS "  # nosec B608 - create_verb is a constant; identifiers escaped via quote_identifier; buffer_expr uses quoted identifiers and numeric distance
             f"SELECT * EXCLUDE ({qg}), "
             f"{buffer_expr} AS {qg} "
             f"FROM {qs}.{qt}"
@@ -164,7 +164,7 @@ class BufferTableAlgorithm(QgsProcessingAlgorithm):
             mgr.execute_query(connection_name, sql, ctx)
             count_cursor = mgr.execute_query(
                 connection_name,
-                f"SELECT COUNT(*) FROM {qs}.{qo}",
+                f"SELECT COUNT(*) FROM {qs}.{qo}",  # nosec B608 - identifiers escaped via quote_identifier
                 ctx,
             )
             count_result = count_cursor.fetchone() if count_cursor else None

--- a/processing/execute_sql.py
+++ b/processing/execute_sql.py
@@ -4,6 +4,7 @@ import os
 
 from qgis.core import (
     QgsProcessingAlgorithm,
+    QgsProcessingException,
     QgsProcessingParameterString,
     QgsProcessingOutputString,
 )
@@ -46,6 +47,50 @@ class ExecuteSQLAlgorithm(QgsProcessingAlgorithm):
     def createInstance(self):
         return ExecuteSQLAlgorithm()
 
+    def flags(self):
+        # SNOW-3712080: run on the main thread so the confirmation prompt below
+        # can be shown safely. This algorithm executes arbitrary SQL on the
+        # user's Snowflake connection and can be triggered by an untrusted
+        # Processing model (.model3), so it must not run unattended in the GUI
+        # without explicit consent.
+        return super().flags() | QgsProcessingAlgorithm.FlagNoThreading
+
+    def _confirm_execution(self, connection_name, sql):
+        """Require explicit user consent when a GUI is available.
+
+        Headless runs (qgis_process CLI / PyQGIS) are treated as user-initiated
+        and proceed without a prompt; interactive runs must be confirmed so a
+        malicious Processing model cannot silently run SQL as the victim.
+        """
+        try:
+            from qgis.utils import iface
+        except Exception:
+            iface = None
+        if iface is None:
+            return True
+
+        from qgis.PyQt.QtWidgets import QMessageBox
+        from qgis.PyQt.QtCore import Qt
+
+        preview = sql if len(sql) <= 2000 else sql[:2000] + "\n…(truncated)"
+        box = QMessageBox(iface.mainWindow())
+        box.setIcon(QMessageBox.Icon.Warning)
+        box.setWindowTitle("Confirm SQL execution")
+        # Plain text so a crafted connection name / SQL cannot render rich text.
+        box.setTextFormat(Qt.TextFormat.PlainText)
+        box.setText(
+            "The Snowflake plugin is about to run a SQL statement on "
+            f"connection '{connection_name}'.\n\n"
+            "Only proceed if you trust the source of this statement (for "
+            "example a Processing model you did not author).\n\n"
+            f"{preview}"
+        )
+        box.setStandardButtons(
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No
+        )
+        box.setDefaultButton(QMessageBox.StandardButton.No)
+        return box.exec() == QMessageBox.StandardButton.Yes
+
     def initAlgorithm(self, config=None):
         self.addParameter(QgsProcessingParameterString(
             self.CONNECTION, self.tr("Connection name"),
@@ -63,6 +108,11 @@ class ExecuteSQLAlgorithm(QgsProcessingAlgorithm):
 
         connection_name = self.parameterAsString(parameters, self.CONNECTION, context)
         sql = self.parameterAsString(parameters, self.SQL, context)
+
+        if not self._confirm_execution(connection_name, sql):
+            raise QgsProcessingException(
+                "Execution of the SQL statement was cancelled by the user."
+            )
 
         auth = get_auth_information(connection_name)
         mgr = SFConnectionManager.get_instance()

--- a/processing/h3_index.py
+++ b/processing/h3_index.py
@@ -110,7 +110,7 @@ class H3IndexAlgorithm(QgsProcessingAlgorithm):
         if not overwrite:
             exists_cursor = mgr.execute_query(
                 connection_name,
-                f"SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES "
+                f"SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES "  # nosec B608 - values escaped via quote_literal
                 f"WHERE TABLE_SCHEMA ILIKE {quote_literal(schema)} "
                 f"AND TABLE_NAME ILIKE {quote_literal(output)}",
                 {"schema_name": schema},
@@ -124,7 +124,7 @@ class H3IndexAlgorithm(QgsProcessingAlgorithm):
 
         create_verb = "CREATE OR REPLACE TABLE" if overwrite else "CREATE TABLE"
         sql = (
-            f"{create_verb} {qs}.{qo} AS "
+            f"{create_verb} {qs}.{qo} AS "  # nosec B608 - create_verb is a constant; identifiers escaped via quote_identifier; resolution is an int
             f"SELECT *, "
             f"H3_LATLNG_TO_CELL(ST_Y({qg}), ST_X({qg}), {resolution}) AS H3_INDEX, "
             f"H3_CELL_TO_BOUNDARY(H3_LATLNG_TO_CELL(ST_Y({qg}), ST_X({qg}), {resolution})) AS H3_BOUNDARY "
@@ -138,7 +138,7 @@ class H3IndexAlgorithm(QgsProcessingAlgorithm):
             mgr.execute_query(connection_name, sql, {"schema_name": schema})
             count_cursor = mgr.execute_query(
                 connection_name,
-                f"SELECT COUNT(*) FROM {qs}.{qo}",
+                f"SELECT COUNT(*) FROM {qs}.{qo}",  # nosec B608 - identifiers escaped via quote_identifier
                 {"schema_name": schema},
             )
             count_result = count_cursor.fetchone() if count_cursor else None

--- a/processing/import_from_snowflake.py
+++ b/processing/import_from_snowflake.py
@@ -172,7 +172,7 @@ class ImportFromSnowflakeAlgorithm(QgsProcessingAlgorithm):
         fq_table = f"{quote_identifier(schema)}.{quote_identifier(table)}"
 
         col_query = (
-            f"SELECT COLUMN_NAME, DATA_TYPE "
+            f"SELECT COLUMN_NAME, DATA_TYPE "  # nosec B608 - values escaped via quote_literal
             f"FROM INFORMATION_SCHEMA.COLUMNS "
             f"WHERE TABLE_SCHEMA ILIKE {quote_literal(schema)} "
             f"AND TABLE_NAME ILIKE {quote_literal(table)} "
@@ -214,9 +214,9 @@ class ImportFromSnowflakeAlgorithm(QgsProcessingAlgorithm):
         select_cols = ", ".join(quote_identifier(c) for c in col_names)
         geo_select = f"ST_ASWKB({quote_identifier(geo_col)}) AS _wkb"
         if select_cols:
-            sql = f"SELECT {select_cols}, {geo_select} FROM {fq_table}"
+            sql = f"SELECT {select_cols}, {geo_select} FROM {fq_table}"  # nosec B608 - select_cols and fq_table built from quote_identifier; geo_select uses quote_identifier
         else:
-            sql = f"SELECT {geo_select} FROM {fq_table}"
+            sql = f"SELECT {geo_select} FROM {fq_table}"  # nosec B608 - fq_table and geo_select built from quote_identifier
         if where:
             sql += f" WHERE {where}"
         if limit > 0:

--- a/processing/import_from_snowflake.py
+++ b/processing/import_from_snowflake.py
@@ -133,6 +133,7 @@ class ImportFromSnowflakeAlgorithm(QgsProcessingAlgorithm):
             quote_literal,
             predicate_has_statement_breakers,
         )
+        from ..helpers.mappings import create_qgs_field
         from ..managers.sf_connection_manager import SFConnectionManager
 
         connection_name = self.parameterAsString(parameters, self.CONNECTION, context)
@@ -207,7 +208,7 @@ class ImportFromSnowflakeAlgorithm(QgsProcessingAlgorithm):
             if col_name.upper() == geo_col.upper():
                 continue
             qt_type = type_map.get(col_type, QMetaType.Type.QString)
-            fields.append(QgsField(col_name, qt_type))
+            fields.append(create_qgs_field(col_name, qt_type))
             col_names.append(col_name)
 
         crs = QgsCoordinateReferenceSystem.fromEpsgId(int(srid))

--- a/processing/import_from_snowflake.py
+++ b/processing/import_from_snowflake.py
@@ -4,6 +4,7 @@ import os
 
 from qgis.core import (
     QgsProcessingAlgorithm,
+    QgsProcessingException,
     QgsProcessingParameterString,
     QgsProcessingParameterNumber,
     QgsProcessingParameterFeatureSink,
@@ -127,7 +128,11 @@ class ImportFromSnowflakeAlgorithm(QgsProcessingAlgorithm):
             get_type_from_table_geo_column,
         )
         from ..helpers.utils import get_auth_information
-        from ..helpers.sql import quote_identifier, quote_literal
+        from ..helpers.sql import (
+            quote_identifier,
+            quote_literal,
+            predicate_has_statement_breakers,
+        )
         from ..managers.sf_connection_manager import SFConnectionManager
 
         connection_name = self.parameterAsString(parameters, self.CONNECTION, context)
@@ -218,6 +223,12 @@ class ImportFromSnowflakeAlgorithm(QgsProcessingAlgorithm):
         else:
             sql = f"SELECT {geo_select} FROM {fq_table}"  # nosec B608 - fq_table and geo_select built from quote_identifier
         if where:
+            if predicate_has_statement_breakers(where):
+                raise QgsProcessingException(
+                    "The WHERE clause contains disallowed SQL tokens "
+                    "(comments, statement terminators, or set operators such "
+                    "as UNION). Please provide a single boolean predicate."
+                )
             sql += f" WHERE {where}"
         if limit > 0:
             sql += f" LIMIT {limit}"

--- a/processing/spatial_join.py
+++ b/processing/spatial_join.py
@@ -106,7 +106,7 @@ class SpatialJoinAlgorithm(QgsProcessingAlgorithm):
         from ..helpers.sql import quote_literal
         cursor = mgr.execute_query(
             connection_name,
-            f"SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS "
+            f"SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS "  # nosec B608 - values escaped via quote_literal
             f"WHERE TABLE_SCHEMA ILIKE {quote_literal(schema)} "
             f"AND TABLE_NAME ILIKE {quote_literal(table)} "
             f"ORDER BY ORDINAL_POSITION",
@@ -147,7 +147,7 @@ class SpatialJoinAlgorithm(QgsProcessingAlgorithm):
         if not overwrite:
             exists_cursor = mgr.execute_query(
                 connection_name,
-                f"SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES "
+                f"SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES "  # nosec B608 - values escaped via quote_literal
                 f"WHERE TABLE_SCHEMA ILIKE {quote_literal(schema)} "
                 f"AND TABLE_NAME ILIKE {quote_literal(output)}",
                 ctx,
@@ -181,7 +181,7 @@ class SpatialJoinAlgorithm(QgsProcessingAlgorithm):
 
         create_verb = "CREATE OR REPLACE TABLE" if overwrite else "CREATE TABLE"
         sql = (
-            f"{create_verb} {qs}.{qo} AS "
+            f"{create_verb} {qs}.{qo} AS "  # nosec B608 - create_verb and predicate are constants; identifiers escaped via quote_identifier; select_clause built from quoted identifiers
             f"SELECT {select_clause} "
             f"FROM {qs}.{ql} a "
             f"JOIN {qs}.{qr} b "
@@ -194,7 +194,7 @@ class SpatialJoinAlgorithm(QgsProcessingAlgorithm):
             mgr.execute_query(connection_name, sql, ctx)
             count_cursor = mgr.execute_query(
                 connection_name,
-                f"SELECT COUNT(*) FROM {qs}.{qo}",
+                f"SELECT COUNT(*) FROM {qs}.{qo}",  # nosec B608 - identifiers escaped via quote_identifier
                 ctx,
             )
             count_result = count_cursor.fetchone() if count_cursor else None

--- a/providers/sf_data_source_provider.py
+++ b/providers/sf_data_source_provider.py
@@ -10,6 +10,7 @@ from qgis.core import (
     QgsField,
     QgsFields,
 )
+from ..helpers.mappings import create_qgs_field
 import snowflake.connector
 
 
@@ -154,8 +155,7 @@ class SFDataProvider(QgsDataProvider):
                         type = QMetaType.Type.Double
                 if type in [QMetaType.Type.QDateTime, QMetaType.Type.QDate, QMetaType.Type.QTime]:
                     type = QMetaType.Type.QString
-                qgsField = QgsField(col[0], type, str(type))
-                qgsField.setSubType(subType)
+                qgsField = create_qgs_field(col[0], type, str(type), sub_type=subType)
                 fields.append(qgsField)
 
             # Create a QgsFeatureSource

--- a/providers/sf_feature_iterator.py
+++ b/providers/sf_feature_iterator.py
@@ -164,7 +164,7 @@ class SFFeatureIterator(QgsAbstractFeatureIterator):
                     try:
                         # Checks if the expression is valid
                         query_verify_expression = (
-                            f"SELECT count(*)"
+                            f"SELECT count(*)"  # nosec B608 - expression is a validated QGIS filter expression entered by the user in their own session; from_clause is pre-quoted
                             f" FROM {self._provider._from_clause}"
                             f" WHERE {expression}"
                             " LIMIT 0"
@@ -179,8 +179,13 @@ class SFFeatureIterator(QgsAbstractFeatureIterator):
                         cur_verify_expression.close()
                         self._expression = expression
                         where_clause_list.append(expression)
-                    except Exception:
-                        pass
+                    except Exception as exc:
+                        QgsMessageLog.logMessage(
+                            f"Filter expression rejected by Snowflake; "
+                            f"running without pushdown. Error: {exc}",
+                            "Snowflake Plugin",
+                            Qgis.MessageLevel.Info,
+                        )
 
             # Apply the subset string filter
             if self._provider.subsetString():
@@ -275,7 +280,7 @@ class SFFeatureIterator(QgsAbstractFeatureIterator):
                 order_limit_clause = f" ORDER BY RANDOM() LIMIT {limit_size_for_type(self._provider._geo_column_type)}"
 
             self.final_query = (
-                "select * from ("
+                "select * from ("  # nosec B608 - from_clause pre-quoted; fragments built from quoted identifiers and validated fragments
                 f"select {fields_name_for_query} "
                 f"{geom_query} {index} "
                 f"from {self._provider._from_clause} where {filter_geo_type} {filter_geom_clause}) "

--- a/providers/sf_feature_iterator.py
+++ b/providers/sf_feature_iterator.py
@@ -9,7 +9,9 @@ from qgis.PyQt.QtCore import QDate, QDateTime, QMetaType, QTime
 
 # PyQGIS
 from ..helpers.limits import limit_size_for_type
-from ..helpers.sql import quote_identifier
+from ..helpers.sql import quote_identifier, quote_literal
+from ..helpers.expression_compiler import compile_expression_to_sql
+from ..managers.sf_connection_manager import build_op_tag
 from ..providers.sf_feature_source import SFFeatureSource
 from qgis.core import (
     QgsAbstractFeatureIterator,
@@ -157,40 +159,32 @@ class SFFeatureIterator(QgsAbstractFeatureIterator):
                 where_clause_list.append(feature_clause)
 
             self._expression = ""
-            # Apply the filter expression
+            # Apply the filter expression. The raw QGIS expression text is
+            # attacker-influenceable (persisted in project files), so it is
+            # compiled to SQL through a whitelist compiler; anything that does
+            # not fully compile is NOT pushed down (QGIS filters client-side).
             if self._request.filterType() == QgsFeatureRequest.FilterExpression:
                 expression = self._request.filterExpression().expression()
                 if expression:
-                    try:
-                        # Checks if the expression is valid
-                        query_verify_expression = (
-                            f"SELECT count(*)"  # nosec B608 - expression is a validated QGIS filter expression entered by the user in their own session; from_clause is pre-quoted
-                            f" FROM {self._provider._from_clause}"
-                            f" WHERE {expression}"
-                            " LIMIT 0"
-                        )
-                        cur_verify_expression = (
-                            self._provider.connection_manager.execute_query(
-                                connection_name=self._provider._connection_name,
-                                query=query_verify_expression,
-                                context_information=self._provider._context_information,
-                            )
-                        )
-                        cur_verify_expression.close()
-                        self._expression = expression
-                        where_clause_list.append(expression)
-                    except Exception as exc:
+                    compiled = compile_expression_to_sql(
+                        expression, self._provider._fields
+                    )
+                    if compiled:
+                        self._expression = compiled
+                        where_clause_list.append(compiled)
+                    else:
                         QgsMessageLog.logMessage(
-                            f"Filter expression rejected by Snowflake; "
-                            f"running without pushdown. Error: {exc}",
+                            "Filter expression could not be safely compiled to "
+                            "SQL; running without pushdown.",
                             "Snowflake Plugin",
                             Qgis.MessageLevel.Info,
                         )
 
-            # Apply the subset string filter
+            # Apply the subset string filter. setSubsetString() only stores a
+            # compiler-validated, fully-quoted predicate, so it is safe to
+            # append verbatim here.
             if self._provider.subsetString():
-                subset_clause = self._provider.subsetString().replace('"', "")
-                where_clause_list.append(subset_clause)
+                where_clause_list.append(self._provider.subsetString())
 
             # Apply the geometry filter
             quoted_geom = quote_identifier(geom_column)
@@ -268,29 +262,42 @@ class SFFeatureIterator(QgsAbstractFeatureIterator):
                 self._provider._geometry_type
             )
 
-            filter_geo_type = f"ST_ASGEOJSON({quoted_geom}):type::string IN ('{self._provider._geometry_type}'"
+            filter_geo_type = f"ST_ASGEOJSON({quoted_geom}):type::string IN ({quote_literal(self._provider._geometry_type)}"  # nosec B608 - geometry_type escaped via quote_literal
             if mapped_type is not None:
-                filter_geo_type += f", '{mapped_type}'"
+                filter_geo_type += f", {quote_literal(mapped_type)}"
             filter_geo_type += ")"
             if self._provider._geo_column_type in ["NUMBER", "TEXT"]:
                 filter_geo_type = f'H3_IS_VALID_CELL({quoted_geom})'
 
-            order_limit_clause = ""
-            if self._provider._is_limited_unordered:
-                order_limit_clause = f" ORDER BY RANDOM() LIMIT {limit_size_for_type(self._provider._geo_column_type)}"
-
-            self.final_query = (
+            base_query = (
                 "select * from ("  # nosec B608 - from_clause pre-quoted; fragments built from quoted identifiers and validated fragments
                 f"select {fields_name_for_query} "
                 f"{geom_query} {index} "
                 f"from {self._provider._from_clause} where {filter_geo_type} {filter_geom_clause}) "
-                f"{where_clause}{order_limit_clause}"
+                f"{where_clause}"
             )
+
+            if self._provider._is_limited_unordered:
+                # A7: let Snowflake's TABLESAMPLE do the random-sample work
+                # on the already-filtered set instead of sorting the entire
+                # resultset with ORDER BY RANDOM().
+                sample_n = limit_size_for_type(self._provider._geo_column_type)
+                self.final_query = (
+                    f"select * from ({base_query}) SAMPLE ({sample_n} ROWS)"  # nosec B608 - base_query is built from quoted identifiers / validated fragments; sample_n is an int
+                )
+            else:
+                self.final_query = base_query
 
             self._result = self._provider.connection_manager.execute_query(
                 connection_name=self._provider._connection_name,
                 query=self.final_query,
                 context_information=self._provider._context_information,
+                op_tag=build_op_tag(
+                    "layer-load",
+                    connection_name=self._provider._connection_name,
+                    schema=self._provider._schema_name,
+                    table=self._provider._table_name,
+                ),
             )
             self._col_index_by_name = {
                 desc.name: idx
@@ -493,4 +500,14 @@ class SFFeatureIterator(QgsAbstractFeatureIterator):
     def close(self) -> bool:
         """end of iterating: free the resources / lock"""
         self._index = -1
+        # SNOW-3712076: release the server-side cursor so an abandoned/cancelled
+        # render does not leak an open SnowflakeCursor on the singleton
+        # connection.
+        result = getattr(self, "_result", None)
+        if result is not None:
+            try:
+                result.close()
+            except Exception:
+                pass
+            self._result = None
         return True

--- a/providers/sf_feature_iterator.py
+++ b/providers/sf_feature_iterator.py
@@ -48,6 +48,10 @@ class SFFeatureIterator(QgsAbstractFeatureIterator):
         self._cursor_batch_rows = []
         super().__init__(request)
         self._provider = source.get_provider()
+        # Initialized unconditionally: nextFeatureFilterExpression() reads
+        # self._expression even when the provider's features are already cached
+        # (the block below that would otherwise set it is skipped). See issue #119.
+        self._expression = ""
 
         self._request = request if request is not None else QgsFeatureRequest()
         self._transform = QgsCoordinateTransform()

--- a/providers/sf_metadata_provider.py
+++ b/providers/sf_metadata_provider.py
@@ -2,6 +2,7 @@ from typing import Dict
 from qgis.core import QgsProviderMetadata
 
 from ..helpers.utils import decodeUri as du
+from ..helpers.utils import connection_uri_token
 
 from .sf_vector_data_provider import SFVectorDataProvider
 
@@ -41,7 +42,7 @@ class SFMetadataProvider(QgsProviderMetadata):
         geo_column_type = parts["geo_column_type"]
         primary_key = parts["primary_key"]
         uri = (
-            f"connection_name={connection_name} sql={sql_query} "
+            f"{connection_uri_token(connection_name)} sql={sql_query} "
             f"schema_name={schema_name} table_name={table_name} srid={srid} "
             f"geo_column={geo_column} geometry_type={geometry_type} geo_column_type={geo_column_type} "
             f"primary_key={primary_key}"

--- a/providers/sf_vector_data_provider.py
+++ b/providers/sf_vector_data_provider.py
@@ -278,7 +278,7 @@ class SFVectorDataProvider(QgsVectorDataProvider):
                             f" {quote_literal(database_name)}"
                         )
                     query = (
-                        "SELECT DISTINCT column_name, data_type, ordinal_position"
+                        "SELECT DISTINCT column_name, data_type, ordinal_position"  # nosec B608 - values escaped via quote_literal; catalog_filter/schema_filter built with quote_literal above
                         " FROM information_schema.columns "
                         f"WHERE table_name ILIKE {quote_literal(self._table_name)}"
                         f"{catalog_filter}"
@@ -415,11 +415,11 @@ class SFVectorDataProvider(QgsVectorDataProvider):
         results = set()
         quoted_col = quote_identifier(column_name)
         query = (
-            f"SELECT DISTINCT {quoted_col} FROM {self._from_clause} "
+            f"SELECT DISTINCT {quoted_col} FROM {self._from_clause} "  # nosec B608 - identifier escaped via quote_identifier; from_clause is pre-quoted
             f"ORDER BY {quoted_col}"
         )
         if limit >= 0:
-            query += f" LIMIT {limit}"
+            query += f" LIMIT {limit}"  # nosec B608 - limit is an int
 
         cur = self.connection_manager.execute_query(
             connection_name=self._connection_name,
@@ -449,7 +449,7 @@ class SFVectorDataProvider(QgsVectorDataProvider):
                 cur = self.connection_manager.execute_query(
                     connection_name=self._connection_name,
                     query=(
-                        f"SELECT COUNT(*) FROM {self._from_clause} "
+                        f"SELECT COUNT(*) FROM {self._from_clause} "  # nosec B608 - from_clause pre-quoted; subsetstring validated by Snowflake with LIMIT 0 probe
                         f"WHERE {subsetstring} LIMIT 0"
                     ),
                     context_information=self._context_information,
@@ -718,9 +718,9 @@ class SFGeoVectorDataProvider(SFVectorDataProvider):
                 if self._is_limited_unordered:
                     self._feature_count = limit_size_for_type(self._geo_column_type)
                 else:
-                    query = f"SELECT COUNT(*) FROM {self._from_clause}"
+                    query = f"SELECT COUNT(*) FROM {self._from_clause}"  # nosec B608 - from_clause pre-quoted
                     if self.subsetString():
-                        query += f" WHERE {self.subsetString()}"
+                        query += f" WHERE {self.subsetString()}"  # nosec B608 - subsetString validated via setSubsetString LIMIT 0 probe
 
                     cur = self.connection_manager.execute_query(
                         connection_name=self._connection_name,
@@ -741,7 +741,7 @@ class SFGeoVectorDataProvider(SFVectorDataProvider):
             else:
                 qgeom = quote_identifier(self._column_geom)
                 query = (
-                    f'SELECT MIN(ST_XMIN({qgeom})), '
+                    f'SELECT MIN(ST_XMIN({qgeom})), '  # nosec B608 - identifier escaped via quote_identifier; from_clause pre-quoted; geometry_type is a provider-internal constant
                     f'MIN(ST_YMIN({qgeom})), '
                     f'MAX(ST_XMAX({qgeom})), '
                     f'MAX(ST_YMAX({qgeom})) '
@@ -775,7 +775,7 @@ class SFH3VectorDataProvider(SFVectorDataProvider):
     ):
         super().__init__(uri, providerOptions, flags)
         qgeom = quote_identifier(self._column_geom)
-        query = f'SELECT H3_IS_VALID_CELL({qgeom}) FROM {self._from_clause} WHERE {qgeom} IS NOT NULL LIMIT 1'
+        query = f'SELECT H3_IS_VALID_CELL({qgeom}) FROM {self._from_clause} WHERE {qgeom} IS NOT NULL LIMIT 1'  # nosec B608 - identifier escaped via quote_identifier; from_clause pre-quoted
 
         cur = self.connection_manager.execute_query(
             connection_name=self._connection_name,
@@ -795,10 +795,10 @@ class SFH3VectorDataProvider(SFVectorDataProvider):
                     self._feature_count = limit_size_for_type(self._geo_column_type)
                     return self._feature_count
 
-                query = f"SELECT COUNT(*) FROM {self._from_clause}"
-                query += f' WHERE H3_IS_VALID_CELL({quote_identifier(self._column_geom)})'
+                query = f"SELECT COUNT(*) FROM {self._from_clause}"  # nosec B608 - from_clause pre-quoted
+                query += f' WHERE H3_IS_VALID_CELL({quote_identifier(self._column_geom)})'  # nosec B608 - identifier escaped via quote_identifier
                 if self.subsetString():
-                    query += f" AND {self.subsetString()}"
+                    query += f" AND {self.subsetString()}"  # nosec B608 - subsetString validated via setSubsetString LIMIT 0 probe
 
                 cur = self.connection_manager.execute_query(
                     connection_name=self._connection_name,
@@ -819,7 +819,7 @@ class SFH3VectorDataProvider(SFVectorDataProvider):
             else:
                 qgeom = quote_identifier(self._column_geom)
                 query = (
-                    f'SELECT MIN(ST_XMIN(H3_CELL_TO_BOUNDARY({qgeom}))), '
+                    f'SELECT MIN(ST_XMIN(H3_CELL_TO_BOUNDARY({qgeom}))), '  # nosec B608 - identifier escaped via quote_identifier; from_clause pre-quoted
                     f'MIN(ST_YMIN(H3_CELL_TO_BOUNDARY({qgeom}))), '
                     f'MAX(ST_XMAX(H3_CELL_TO_BOUNDARY({qgeom}))), '
                     f'MAX(ST_YMAX(H3_CELL_TO_BOUNDARY({qgeom}))) '

--- a/providers/sf_vector_data_provider.py
+++ b/providers/sf_vector_data_provider.py
@@ -1,4 +1,5 @@
 import copy
+import re
 import typing
 from qgis.core import (
     Qgis,
@@ -22,8 +23,11 @@ from .sf_feature_iterator import SFFeatureIterator
 from ..helpers.data_base import (
     alter_table_add_columns,
     alter_table_drop_columns,
+    check_column_has_duplicates,
     check_from_clause_exceeds_size,
     delete_table_features,
+    get_cheap_row_count,
+    get_declared_primary_key,
     get_next_primary_key_value,
     insert_table_feature,
     limit_size_for_type,
@@ -33,11 +37,16 @@ from ..helpers.data_base import (
 
 from .sf_feature_source import SFFeatureSource
 
-from ..helpers.utils import get_authentification_information, get_qsettings
-from ..managers.sf_connection_manager import SFConnectionManager
+from ..helpers.utils import (
+    get_authentification_information,
+    get_or_create_connection_authcfg,
+    get_qsettings,
+)
+from ..managers.sf_connection_manager import SFConnectionManager, build_op_tag
 
 from ..helpers.wrapper import parse_uri
 from ..helpers.sql import quote_identifier, quote_literal
+from ..helpers.expression_compiler import compile_expression_to_sql
 from ..helpers.mappings import (
     SNOWFLAKE_METADATA_TYPE_CODE_DICT,
     mapping_snowflake_qgis_geometry,
@@ -66,6 +75,9 @@ class SFVectorDataProvider(QgsVectorDataProvider):
         self._feature_count = None
         self.filter_where_clause = None
         self._load_all_rows = False
+        # SNOW-3712083: cache for the "is the URI-supplied primary_key actually
+        # unique?" check (None = not yet computed).
+        self._primary_key_is_valid = None
         try:
             (
                 self._connection_name,
@@ -113,16 +125,38 @@ class SFVectorDataProvider(QgsVectorDataProvider):
 
         if self._sql_query and not self._table_name:
             self._from_clause = f"({self._sql_query})"
+            # SNOW-3712076: a custom sql_query layer must still be row-capped so
+            # a malicious project file cannot force an unbounded fetch (client
+            # OOM + uncapped warehouse spend). There is no table to consult for
+            # a cheap ROW_COUNT, so probe the wrapped query directly.
+            if self._load_all_rows:
+                self._is_limited_unordered = False
+            else:
+                limit_size = limit_size_for_type(self._geo_column_type)
+                self._is_limited_unordered = check_from_clause_exceeds_size(
+                    from_clause=self._from_clause,
+                    context_information=self._context_information,
+                    limit_size=limit_size,
+                )
         else:
             self._from_clause = quote_identifier(self._table_name)
             if self._load_all_rows:
                 self._is_limited_unordered = False
             else:
-                self._is_limited_unordered = check_from_clause_exceeds_size(
-                    from_clause=self._from_clause,
-                    context_information=self._context_information,
-                    limit_size=limit_size_for_type(self._geo_column_type),
-                )
+                limit_size = limit_size_for_type(self._geo_column_type)
+                # A4: try the free INFORMATION_SCHEMA path before falling back
+                # to a blocking COUNT(*). For views / subqueries / tables that
+                # don't expose ROW_COUNT we still pay for the scan, but that's
+                # rare and unavoidable.
+                cheap = get_cheap_row_count(self._context_information)
+                if cheap is not None:
+                    self._is_limited_unordered = cheap > limit_size
+                else:
+                    self._is_limited_unordered = check_from_clause_exceeds_size(
+                        from_clause=self._from_clause,
+                        context_information=self._context_information,
+                        limit_size=limit_size,
+                    )
 
         self.get_geometry_column()
 
@@ -161,6 +195,40 @@ class SFVectorDataProvider(QgsVectorDataProvider):
         else:
             return base_provider
 
+    def _validate_primary_key(self) -> bool:
+        """Return True only if the URI-supplied primary_key is actually unique.
+
+        SNOW-3712083: the primary_key= URI component is persisted verbatim in
+        .qgs/.qgz project files and is never re-checked on load, so a malicious
+        project could point it at a non-unique column and turn a single-feature
+        edit into a mass UPDATE/DELETE. We re-validate here (cheap declared-PK
+        match first, duplicate-count fallback) and cache the result. Any failure
+        fails closed (treated as not-unique / read-only).
+        """
+        if self._primary_key_is_valid is not None:
+            return self._primary_key_is_valid
+
+        result = False
+        try:
+            if self._primary_key and self._table_name:
+                declared = get_declared_primary_key(self._context_information)
+                if declared and declared.upper() == self._primary_key.upper():
+                    result = True
+                else:
+                    result = not check_column_has_duplicates(
+                        self._context_information, self._primary_key
+                    )
+        except Exception as e:
+            QgsMessageLog.logMessage(
+                f"Primary key validation failed; treating layer as read-only: {e}",
+                "Snowflake Plugin",
+                Qgis.MessageLevel.Warning,
+            )
+            result = False
+
+        self._primary_key_is_valid = result
+        return result
+
     def capabilities(self) -> QgsVectorDataProvider.Capabilities:
         base_capabilities = (
             QgsVectorDataProvider.CreateSpatialIndex | QgsVectorDataProvider.SelectAtId
@@ -171,6 +239,8 @@ class SFVectorDataProvider(QgsVectorDataProvider):
             self._primary_key == ""
             or self._geo_column_type not in ("GEOGRAPHY", "GEOMETRY")
             or (self._sql_query is not None and self._sql_query != "")
+            or self._is_limited_unordered
+            or not self._validate_primary_key()
         ):
             reasons = []
             if self._primary_key == "":
@@ -179,6 +249,18 @@ class SFVectorDataProvider(QgsVectorDataProvider):
                 reasons.append(f"column type '{self._geo_column_type}' is not editable")
             if self._sql_query is not None and self._sql_query != "":
                 reasons.append("custom SQL query layer")
+            # SNOW-3712082: a randomly-sampled / unordered result set has no
+            # stable feature ids, so edits could hit the wrong rows.
+            if self._is_limited_unordered:
+                reasons.append("row-capped/unordered result (unstable feature ids)")
+            # SNOW-3712083: refuse edits when the declared primary key cannot be
+            # confirmed unique.
+            if (
+                self._primary_key != ""
+                and not self._is_limited_unordered
+                and not self._validate_primary_key()
+            ):
+                reasons.append("primary key is not verified unique")
             QgsMessageLog.logMessage(
                 f"Layer read-only: {', '.join(reasons)} "
                 f"(table={getattr(self, '_table_name', '?')})",
@@ -362,13 +444,46 @@ class SFVectorDataProvider(QgsVectorDataProvider):
             return ""
         return "Autogenerated"
 
-    def dataSourceUri(self, expandAuthConfig=False):
-        """Returns the data source specification: database path and
-        table name.
+    # URI keys used to find the boundary of the leading connection token.
+    _URI_TOKEN_KEYS = (
+        "connection_name", "authcfg", "sql_query", "sql", "schema_name",
+        "table_name", "srid", "geom_column", "geometry_type",
+        "geo_column_type", "primary_key", "load_all_rows",
+    )
 
-        :param bool expandAuthConfig: expand credentials (unused)
+    @classmethod
+    def _replace_connection_token(cls, uri: str, new_token: str) -> str:
+        """Swap the leading connection_name=/authcfg= token for new_token."""
+        pattern = r"(?:connection_name|authcfg)=.*?(?= (?:%s)=|$)" % "|".join(
+            cls._URI_TOKEN_KEYS
+        )
+        stripped = re.sub(pattern, "", uri, count=1, flags=re.DOTALL).strip()
+        return f"{new_token} {stripped}".strip()
+
+    def dataSourceUri(self, expandAuthConfig=False):
+        """Returns the data source specification.
+
+        SNOW-3712094: the URI is serialised verbatim into .qgs/.qgz/.qlr files.
+        When QGIS asks for the storable form (expandAuthConfig=False) we must
+        never emit the raw connection alias, so we swap it for the redacted
+        authcfg= token. Only when a caller explicitly requests the expanded
+        form do we return the alias.
+
+        :param bool expandAuthConfig: expand the auth config to the alias
         :returns: the data source uri
         """
+        if expandAuthConfig:
+            if "authcfg=" in self._uri and self._connection_name:
+                return self._replace_connection_token(
+                    self._uri, f"connection_name={self._connection_name}"
+                )
+            return self._uri
+
+        if "authcfg=" in self._uri:
+            return self._uri
+        config_id = get_or_create_connection_authcfg(self._connection_name)
+        if config_id:
+            return self._replace_connection_token(self._uri, f"authcfg={config_id}")
         return self._uri
 
     def crs(self):
@@ -444,20 +559,20 @@ class SFVectorDataProvider(QgsVectorDataProvider):
         self, subsetstring: str, updateFeatureCount: bool = True
     ) -> bool:
         if subsetstring:
-            # Check if the filter is valid
-            try:
-                cur = self.connection_manager.execute_query(
-                    connection_name=self._connection_name,
-                    query=(
-                        f"SELECT COUNT(*) FROM {self._from_clause} "  # nosec B608 - from_clause pre-quoted; subsetstring validated by Snowflake with LIMIT 0 probe
-                        f"WHERE {subsetstring} LIMIT 0"
-                    ),
-                    context_information=self._context_information,
+            # The subset string is persisted verbatim in project files, so it
+            # is compiled through the whitelist expression compiler rather than
+            # trusted as raw SQL. Only a fully-compiled, quoted predicate is
+            # stored; anything else is refused.
+            compiled = compile_expression_to_sql(subsetstring, self.fields())
+            if not compiled:
+                QgsMessageLog.logMessage(
+                    "Subset string could not be safely compiled to SQL; "
+                    "rejecting it.",
+                    "Snowflake Plugin",
+                    Qgis.MessageLevel.Warning,
                 )
-                cur.close()
-            except Exception as _:
                 return False
-            self.filter_where_clause = subsetstring
+            self.filter_where_clause = compiled
 
         if not subsetstring:
             self.filter_where_clause = None
@@ -720,12 +835,18 @@ class SFGeoVectorDataProvider(SFVectorDataProvider):
                 else:
                     query = f"SELECT COUNT(*) FROM {self._from_clause}"  # nosec B608 - from_clause pre-quoted
                     if self.subsetString():
-                        query += f" WHERE {self.subsetString()}"  # nosec B608 - subsetString validated via setSubsetString LIMIT 0 probe
+                        query += f" WHERE {self.subsetString()}"  # nosec B608 - subsetString is compiler-validated & quoted in setSubsetString
 
                     cur = self.connection_manager.execute_query(
                         connection_name=self._connection_name,
                         query=query,
                         context_information=self._context_information,
+                        op_tag=build_op_tag(
+                            "featurecount",
+                            connection_name=self._connection_name,
+                            schema=self._schema_name,
+                            table=self._table_name,
+                        ),
                     )
 
                     self._feature_count = cur.fetchone()[0]
@@ -741,19 +862,25 @@ class SFGeoVectorDataProvider(SFVectorDataProvider):
             else:
                 qgeom = quote_identifier(self._column_geom)
                 query = (
-                    f'SELECT MIN(ST_XMIN({qgeom})), '  # nosec B608 - identifier escaped via quote_identifier; from_clause pre-quoted; geometry_type is a provider-internal constant
+                    f'SELECT MIN(ST_XMIN({qgeom})), '  # nosec B608 - identifier escaped via quote_identifier; from_clause pre-quoted; geometry_type escaped via quote_literal
                     f'MIN(ST_YMIN({qgeom})), '
                     f'MAX(ST_XMAX({qgeom})), '
                     f'MAX(ST_YMAX({qgeom})) '
                     f"FROM {self._from_clause} "
                     f'WHERE {qgeom} IS NOT NULL AND '
-                    f"ST_ASGEOJSON({qgeom}):type ILIKE '{self._geometry_type}'"
+                    f"ST_ASGEOJSON({qgeom}):type ILIKE {quote_literal(self._geometry_type)}"
                 )
 
                 cur = self.connection_manager.execute_query(
                     connection_name=self._connection_name,
                     query=query,
                     context_information=self._context_information,
+                    op_tag=build_op_tag(
+                        "extent",
+                        connection_name=self._connection_name,
+                        schema=self._schema_name,
+                        table=self._table_name,
+                    ),
                 )
 
                 extent_bounds = cur.fetchone()
@@ -798,12 +925,18 @@ class SFH3VectorDataProvider(SFVectorDataProvider):
                 query = f"SELECT COUNT(*) FROM {self._from_clause}"  # nosec B608 - from_clause pre-quoted
                 query += f' WHERE H3_IS_VALID_CELL({quote_identifier(self._column_geom)})'  # nosec B608 - identifier escaped via quote_identifier
                 if self.subsetString():
-                    query += f" AND {self.subsetString()}"  # nosec B608 - subsetString validated via setSubsetString LIMIT 0 probe
+                    query += f" AND {self.subsetString()}"  # nosec B608 - subsetString is compiler-validated & quoted in setSubsetString
 
                 cur = self.connection_manager.execute_query(
                     connection_name=self._connection_name,
                     query=query,
                     context_information=self._context_information,
+                    op_tag=build_op_tag(
+                        "featurecount",
+                        connection_name=self._connection_name,
+                        schema=self._schema_name,
+                        table=self._table_name,
+                    ),
                 )
 
                 self._feature_count = cur.fetchone()[0]
@@ -831,6 +964,12 @@ class SFH3VectorDataProvider(SFVectorDataProvider):
                     connection_name=self._connection_name,
                     query=query,
                     context_information=self._context_information,
+                    op_tag=build_op_tag(
+                        "extent",
+                        connection_name=self._connection_name,
+                        schema=self._schema_name,
+                        table=self._table_name,
+                    ),
                 )
 
                 extent_bounds = cur.fetchone()

--- a/providers/sf_vector_data_provider.py
+++ b/providers/sf_vector_data_provider.py
@@ -49,6 +49,7 @@ from ..helpers.sql import quote_identifier, quote_literal
 from ..helpers.expression_compiler import compile_expression_to_sql
 from ..helpers.mappings import (
     SNOWFLAKE_METADATA_TYPE_CODE_DICT,
+    create_qgs_field,
     mapping_snowflake_qgis_geometry,
     mapping_snowflake_qgis_type,
 )
@@ -379,7 +380,7 @@ class SFVectorDataProvider(QgsVectorDataProvider):
                     cur.close()
                     for row in field_info:
                         field_name, field_type = row[0], row[1]
-                        qgs_field = QgsField(
+                        qgs_field = create_qgs_field(
                             field_name, mapping_snowflake_qgis_type[field_type]
                         )
                         self._fields.append(qgs_field)
@@ -396,7 +397,7 @@ class SFVectorDataProvider(QgsVectorDataProvider):
                     for data in description:
                         # it is already used to set the feature id
                         if data[1] not in [14, 15]:
-                            qgs_field = QgsField(
+                            qgs_field = create_qgs_field(
                                 data[0],
                                 SNOWFLAKE_METADATA_TYPE_CODE_DICT.get(
                                     data[1],

--- a/qgis_snowflake_connector.py
+++ b/qgis_snowflake_connector.py
@@ -114,10 +114,18 @@ class QGISSnowflakeConnectorPlugin(object):
                 "https://api.github.com/repos/"
                 "snowflakedb/qgis-snowflake-connector/releases/latest"
             )
+            # Defence-in-depth: the URL is a hardcoded constant, but validate
+            # scheme/host explicitly before opening it to satisfy static
+            # analysers (bandit B310) and protect against future refactors.
+            from urllib.parse import urlparse
+
+            parsed = urlparse(url)
+            if parsed.scheme != "https" or parsed.netloc != "api.github.com":
+                return
             req = urllib.request.Request(
                 url, headers={"Accept": "application/vnd.github.v3+json"}
             )
-            with urllib.request.urlopen(req, timeout=5) as resp:
+            with urllib.request.urlopen(req, timeout=5) as resp:  # nosec B310 - scheme/host validated to https://api.github.com above
                 data = json.loads(resp.read().decode())
             remote_tag = data.get("tag_name", "").lstrip("v")
             if not remote_tag:
@@ -133,7 +141,7 @@ class QGISSnowflakeConnectorPlugin(object):
                     "Snowflake Plugin",
                     Qgis.MessageLevel.Info,
                 )
-        except Exception:
+        except Exception:  # nosec B110 - update check runs in a daemon thread during plugin init; never block QGIS startup on network or version-parse errors
             pass
 
     def initGui(self):
@@ -146,7 +154,7 @@ class QGISSnowflakeConnectorPlugin(object):
             if iface:
                 iface.registerLocatorFilter(self.locator_filter)
                 self.iface = iface
-        except Exception:
+        except Exception:  # nosec B110 - locator filter is optional; missing iface or registration failure must not prevent plugin init
             pass
 
         register_sf_functions()

--- a/qgis_snowflake_connector_algorithm.py
+++ b/qgis_snowflake_connector_algorithm.py
@@ -52,6 +52,8 @@ import json
 import typing
 from qgis.PyQt.QtCore import QCoreApplication, QByteArray, QVariant, QMetaType
 from qgis.core import (
+    Qgis,
+    QgsMessageLog,
     QgsProcessing,
     QgsProcessingAlgorithm,
     QgsProcessingException,
@@ -279,7 +281,7 @@ class QGISSnowflakeConnectorAlgorithm(QgsProcessingAlgorithm):
         variant_columns = set()
         try:
             variant_query = (
-                "SELECT column_name FROM information_schema.columns "
+                "SELECT column_name FROM information_schema.columns "  # nosec B608 - values escaped via quote_literal
                 f"WHERE table_catalog ILIKE {quote_literal(selected_database)} "
                 f"AND table_schema ILIKE {quote_literal(selected_schema)} "
                 f"AND table_name ILIKE {quote_literal(selected_table)} "
@@ -290,8 +292,12 @@ class QGISSnowflakeConnectorAlgorithm(QgsProcessingAlgorithm):
             )
             variant_columns = {row[0] for row in cur.fetchall()}
             cur.close()
-        except Exception:
-            pass
+        except Exception as exc:
+            QgsMessageLog.logMessage(
+                f"variant column detection skipped: {exc}",
+                "Snowflake Plugin",
+                Qgis.MessageLevel.Info,
+            )
 
         total = 100.0 / source.featureCount() if source.featureCount() else 0
         features = source.getFeatures()
@@ -333,7 +339,7 @@ class QGISSnowflakeConnectorAlgorithm(QgsProcessingAlgorithm):
             tuple_position += 1
 
         query_base = (
-            f'INSERT INTO {fq_table} ({query_columns}) '
+            f'INSERT INTO {fq_table} ({query_columns}) '  # nosec B608 - fq_table built via qualified_table_name; query_columns built from quote_identifier; select_projection uses fixed aliases
             f"SELECT {','.join(select_projection)} FROM VALUES "
         )
         query_values_alias = f" AS v({','.join(value_aliases)})"
@@ -626,7 +632,7 @@ class QGISSnowflakeConnectorAlgorithm(QgsProcessingAlgorithm):
                     WHERE TABLE_CATALOG ILIKE {quote_literal(selected_database)}
                     AND TABLE_SCHEMA ILIKE {quote_literal(selected_schema)}
                     AND TABLE_NAME ILIKE {quote_literal(selected_table)}
-                """
+                """  # nosec B608 - values escaped via quote_literal
                 cur_select_columns = self.sf_data_provider.execute_query(
                     query_select_columns, selected_connection
                 )

--- a/sf_locator_filter.py
+++ b/sf_locator_filter.py
@@ -54,7 +54,7 @@ class SFLocatorFilter(QgsLocatorFilter):
                         mgr.connect(conn_name, auth)
 
                     sql = (
-                        f"SELECT TABLE_SCHEMA, TABLE_NAME "
+                        f"SELECT TABLE_SCHEMA, TABLE_NAME "  # nosec B608 - value escaped via quote_literal
                         f"FROM INFORMATION_SCHEMA.TABLES "
                         f"WHERE TABLE_NAME ILIKE {quote_literal(f'%{string}%')} "
                         f"AND TABLE_SCHEMA != 'INFORMATION_SCHEMA' "
@@ -115,7 +115,7 @@ class SFLocatorFilter(QgsLocatorFilter):
                 mgr.connect(conn_name, auth)
 
             geo_query = (
-                f"SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS "
+                f"SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS "  # nosec B608 - values escaped via quote_literal
                 f"WHERE TABLE_SCHEMA ILIKE {quote_literal(schema)} "
                 f"AND TABLE_NAME ILIKE {quote_literal(table)} "
                 f"AND DATA_TYPE IN ('GEOGRAPHY', 'GEOMETRY') "

--- a/sf_temporal_support.py
+++ b/sf_temporal_support.py
@@ -58,7 +58,7 @@ def configure_temporal_for_layer(layer):
 
         types_in = ", ".join(quote_literal(t) for t in TIMESTAMP_TYPES)
         sql = (
-            f"SELECT COLUMN_NAME, DATA_TYPE "
+            f"SELECT COLUMN_NAME, DATA_TYPE "  # nosec B608 - values escaped via quote_literal; types_in built from quote_literal over fixed allowlist
             f"FROM INFORMATION_SCHEMA.COLUMNS "
             f"WHERE TABLE_SCHEMA ILIKE {quote_literal(schema)} "
             f"AND TABLE_NAME ILIKE {quote_literal(table)} "

--- a/sf_temporal_support.py
+++ b/sf_temporal_support.py
@@ -5,12 +5,16 @@ QgsVectorLayerTemporalProperties so users can use the QGIS temporal
 controller for time-based animation.
 """
 
+from datetime import date, datetime
+
 from qgis.core import (
+    QgsDateTimeRange,
     QgsProviderRegistry,
     QgsVectorLayerTemporalProperties,
     QgsMessageLog,
     Qgis,
 )
+from qgis.PyQt.QtCore import QDateTime, Qt
 
 TIMESTAMP_TYPES = frozenset({
     "TIMESTAMP_NTZ", "TIMESTAMP_LTZ", "TIMESTAMP_TZ",
@@ -104,8 +108,77 @@ def configure_temporal_for_layer(layer):
     props.setStartField(ts_field_name)
     props.setIsActive(True)
 
+    # D4: populate the layer's fixed temporal range with the actual MIN/MAX
+    # of the timestamp column so the QGIS temporal controller opens on the
+    # right window instead of defaulting to "now" / empty.
+    _apply_fixed_temporal_range(props, mgr, conn_name, schema, table, ts_field_name)
+
     QgsMessageLog.logMessage(
         f"Temporal animation enabled for '{layer.name()}' using column '{ts_field_name}'",
         "Snowflake Plugin",
         Qgis.MessageLevel.Info,
     )
+
+
+def _to_qdatetime(value):
+    """Convert a Snowflake-returned datetime/date value to a QDateTime.
+
+    Snowflake's TIMESTAMP variants deserialize to python ``datetime`` (with or
+    without tzinfo); DATE deserializes to ``date``. Returns ``None`` if the
+    value cannot be converted.
+    """
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        qdt = QDateTime.fromString(value.isoformat(), Qt.DateFormat.ISODateWithMs)
+        if not qdt.isValid():
+            qdt = QDateTime.fromString(value.isoformat(), Qt.DateFormat.ISODate)
+        return qdt if qdt.isValid() else None
+    if isinstance(value, date):
+        qdt = QDateTime.fromString(value.isoformat(), Qt.DateFormat.ISODate)
+        return qdt if qdt.isValid() else None
+    return None
+
+
+def _apply_fixed_temporal_range(props, mgr, conn_name, schema, table, ts_field_name):
+    """Query MIN/MAX of the timestamp column once and set the layer's
+    ``fixedTemporalRange`` so the temporal controller knows the span without
+    scanning every feature on demand.
+    """
+    try:
+        from .helpers.sql import quote_identifier
+        from .managers.sf_connection_manager import build_op_tag
+
+        qcol = quote_identifier(ts_field_name)
+        qtbl = f"{quote_identifier(schema)}.{quote_identifier(table)}"
+        sql = f"SELECT MIN({qcol}), MAX({qcol}) FROM {qtbl}"  # nosec B608 - identifiers quoted via quote_identifier
+        cursor = mgr.execute_query(
+            conn_name,
+            sql,
+            {"schema_name": schema},
+            op_tag=build_op_tag(
+                "temporal-range",
+                connection_name=conn_name,
+                schema=schema,
+                table=table,
+            ),
+        )
+        row = cursor.fetchone() if cursor else None
+        cursor.close() if cursor else None
+    except Exception as e:
+        QgsMessageLog.logMessage(
+            f"Temporal range probe failed: {e}",
+            "Snowflake Plugin",
+            Qgis.MessageLevel.Info,
+        )
+        return
+
+    if not row:
+        return
+
+    q_min = _to_qdatetime(row[0])
+    q_max = _to_qdatetime(row[1])
+    if q_min is None or q_max is None:
+        return
+
+    props.setFixedTemporalRange(QgsDateTimeRange(q_min, q_max))

--- a/tasks/sf_connect_task.py
+++ b/tasks/sf_connect_task.py
@@ -1,6 +1,7 @@
 import typing
 
 from ..helpers.data_base import get_geo_columns
+from ..helpers.sql import quote_literal
 from ..helpers.utils import get_authentification_information, get_qsettings
 from ..providers.sf_data_source_provider import SFDataProvider
 from qgis.core import QgsTask
@@ -32,10 +33,10 @@ class SFConnectTask(QgsTask):
             self.query = f"""
             SELECT TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, COMMENT, COLUMN_NAME, DATA_TYPE
             FROM INFORMATION_SCHEMA.COLUMNS
-            WHERE TABLE_CATALOG = '{self.auth_information["database"].upper()}'
+            WHERE TABLE_CATALOG = {quote_literal(self.auth_information["database"].upper())}
             AND DATA_TYPE in ('GEOGRAPHY', 'GEOMETRY', 'NUMBER', 'TEXT')
             ORDER BY TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME, DATA_TYPE
-            """
+            """  # nosec B608 - value escaped via quote_literal
             self.connection_name = connection_name
         except Exception as e:
             self.on_handle_error.emit(

--- a/tasks/sf_connect_task.py
+++ b/tasks/sf_connect_task.py
@@ -1,8 +1,10 @@
+import threading
 import typing
 
 from ..helpers.data_base import get_geo_columns
 from ..helpers.sql import quote_literal
 from ..helpers.utils import get_authentification_information, get_qsettings
+from ..managers.sf_connection_manager import SFConnectionManager
 from ..providers.sf_data_source_provider import SFDataProvider
 from qgis.core import QgsTask
 from qgis.PyQt.QtCore import pyqtSignal
@@ -26,6 +28,7 @@ class SFConnectTask(QgsTask):
         """
         try:
             super().__init__("Snowflake Connection Task", QgsTask.CanCancel)
+            self._run_thread_id: typing.Optional[int] = None
             self.settings = get_qsettings()
             self.auth_information = get_authentification_information(
                 self.settings, connection_name
@@ -52,6 +55,7 @@ class SFConnectTask(QgsTask):
             bool: True if the task is executed successfully, False otherwise.
         """
         try:
+            self._run_thread_id = threading.get_ident()
             sf_data_provider = SFDataProvider(self.auth_information)
             columns = get_geo_columns(sf_data_provider, self.connection_name)
             columns.sort(
@@ -104,6 +108,14 @@ class SFConnectTask(QgsTask):
                 f"Running sf connect task failed.\n\nExtended error information:\n{str(e)}",
             )
             return False
+
+    def cancel(self) -> None:
+        """Propagate user cancel to any in-flight Snowflake query (A9)."""
+        if self._run_thread_id is not None:
+            SFConnectionManager.get_instance().cancel_pending_on_thread(
+                self._run_thread_id
+            )
+        super().cancel()
 
     def finished(self, result: bool) -> None:
         """

--- a/tasks/sf_convert_column_to_layer_task.py
+++ b/tasks/sf_convert_column_to_layer_task.py
@@ -1,8 +1,13 @@
+import threading
+import typing
+
 from ..helpers.data_base import (
     get_geo_column_type,
     get_srid_from_table_geo_column,
     get_type_from_table_geo_column,
 )
+from ..managers.sf_connection_manager import SFConnectionManager
+from ..helpers.utils import connection_uri_token
 from qgis.core import QgsProject, QgsTask, QgsVectorLayer
 from qgis.PyQt.QtCore import pyqtSignal
 
@@ -42,6 +47,7 @@ class SFConvertColumnToLayerTask(QgsTask):
             self.load_all_rows = load_all_rows
 
             self.path = path
+            self._run_thread_id: typing.Optional[int] = None
             super().__init__(
                 f"Snowflake Add Map Layer From {self.schema}.{self.table}.{self.column}",
                 QgsTask.CanCancel,
@@ -60,6 +66,7 @@ class SFConvertColumnToLayerTask(QgsTask):
             bool: True if the task is executed successfully, False otherwise.
         """
         try:
+            self._run_thread_id = threading.get_ident()
             geo_column_type = get_geo_column_type(
                 geo_column_name=self.column,
                 context_information=self.context_information,
@@ -85,7 +92,7 @@ class SFConvertColumnToLayerTask(QgsTask):
 
             for geo_type in geo_type_list:
                 uri = (
-                    f"connection_name={self.connection_name} sql_query= "
+                    f"{connection_uri_token(self.connection_name)} sql_query= "
                     f"schema_name={self.schema} "
                     f"table_name={self.table} srid={srid} "
                     f"geom_column={self.column} "
@@ -110,6 +117,14 @@ class SFConvertColumnToLayerTask(QgsTask):
                 f"Running snowflake convert column to layer task failed.\n\nExtended error information:\n{str(e)}",
             )
             return False
+
+    def cancel(self) -> None:
+        """Propagate user cancel to any in-flight Snowflake query (A9)."""
+        if self._run_thread_id is not None:
+            SFConnectionManager.get_instance().cancel_pending_on_thread(
+                self._run_thread_id
+            )
+        super().cancel()
 
     def finished(self, result: bool) -> None:
         """

--- a/tasks/sf_convert_sql_query_to_layer_task.py
+++ b/tasks/sf_convert_sql_query_to_layer_task.py
@@ -1,3 +1,4 @@
+import threading
 import typing
 from ..enums.snowflake_metadata_type import SnowflakeMetadataType
 from ..helpers.data_base import (
@@ -5,6 +6,7 @@ from ..helpers.data_base import (
     get_srid_from_sql_query_geo_column,
     get_type_from_query_geo_column,
 )
+from ..managers.sf_connection_manager import SFConnectionManager
 from qgis.core import QgsProject, QgsTask, QgsVectorLayer
 from qgis.PyQt.QtCore import pyqtSignal
 
@@ -38,6 +40,7 @@ class SFConvertSQLQueryToLayerTask(QgsTask):
 
             self.query = query
             self.layer_name = layer_name
+            self._run_thread_id: typing.Optional[int] = None
             super().__init__(
                 f"Snowflake convert query to layer: {self.query}",
                 QgsTask.CanCancel,
@@ -56,6 +59,7 @@ class SFConvertSQLQueryToLayerTask(QgsTask):
             bool: True if the task is executed successfully, False otherwise.
         """
         try:
+            self._run_thread_id = threading.get_ident()
             if self.geo_column_type_is_h3:
                 geo_column_type = (
                     "TEXT" if self.h3_sf_col_type == SnowflakeMetadataType.TEXT.value
@@ -108,6 +112,14 @@ class SFConvertSQLQueryToLayerTask(QgsTask):
                 f"Running snowflake convert column to layer task failed.\n\nExtended error information:\n{str(e)}",
             )
             return False
+
+    def cancel(self) -> None:
+        """Propagate user cancel to any in-flight Snowflake query (A9)."""
+        if self._run_thread_id is not None:
+            SFConnectionManager.get_instance().cancel_pending_on_thread(
+                self._run_thread_id
+            )
+        super().cancel()
 
     def finished(self, result: bool) -> None:
         """

--- a/tasks/sf_execute_sql_query_task.py
+++ b/tasks/sf_execute_sql_query_task.py
@@ -1,6 +1,8 @@
+import threading
 import typing
 
 from ..helpers.data_base import get_limit_sql_query
+from ..managers.sf_connection_manager import SFConnectionManager
 from qgis.core import QgsTask
 from qgis.PyQt.QtCore import pyqtSignal
 
@@ -34,6 +36,7 @@ class SFExecuteSQLQueryTask(QgsTask):
             )
             self.context_information = context_information
             self.limit = limit
+            self._run_thread_id: typing.Optional[int] = None
         except Exception as e:
             self.on_handle_error.emit(
                 "SFExecuteSQLQueryTask init failed",
@@ -51,6 +54,7 @@ class SFExecuteSQLQueryTask(QgsTask):
             Emits an error signal with detailed error information if an exception occurs.
         """
         try:
+            self._run_thread_id = threading.get_ident()
             self._result = get_limit_sql_query(
                 query=self.query,
                 context_information=self.context_information,
@@ -64,6 +68,14 @@ class SFExecuteSQLQueryTask(QgsTask):
                 f"Running snowflake convert column to layer task failed.\n\nExtended error information:\n{str(e)}",
             )
             return False
+
+    def cancel(self) -> None:
+        """Propagate user cancel to any in-flight Snowflake query (A9)."""
+        if self._run_thread_id is not None:
+            SFConnectionManager.get_instance().cancel_pending_on_thread(
+                self._run_thread_id
+            )
+        super().cancel()
 
     def finished(self, result: bool) -> None:
         """

--- a/test/test_issue_regressions.py
+++ b/test/test_issue_regressions.py
@@ -1,8 +1,61 @@
 import pathlib
+import re
 import unittest
 
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+def _load_helpers_utils(testcase):
+    """Load helpers/utils.py against a self-contained qgis stub.
+
+    Registers/restores the qgis modules in sys.modules (via the testcase's
+    addCleanup) so it does not perturb the fragile shared stubs used by other
+    tests in this module.
+    """
+    import sys
+    import types
+    import importlib.util
+
+    names = (
+        "qgis", "qgis.core", "qgis.PyQt", "qgis.PyQt.QtCore",
+        "qgis.PyQt.QtWidgets",
+    )
+    saved = {n: sys.modules.get(n) for n in names}
+
+    def _restore():
+        for n, prev in saved.items():
+            if prev is None:
+                sys.modules.pop(n, None)
+            else:
+                sys.modules[n] = prev
+    testcase.addCleanup(_restore)
+
+    qgis = types.ModuleType("qgis")
+    core = types.ModuleType("qgis.core")
+    core.QgsApplication = type("QgsApplication", (), {})
+    core.QgsAuthMethodConfig = type("QgsAuthMethodConfig", (), {})
+    qgis.core = core
+    pyqt = types.ModuleType("qgis.PyQt")
+    qtcore = types.ModuleType("qgis.PyQt.QtCore")
+    qtcore.QSettings = type("QSettings", (), {})
+    pyqt.QtCore = qtcore
+    qtwidgets = types.ModuleType("qgis.PyQt.QtWidgets")
+    qtwidgets.QMessageBox = type("QMessageBox", (), {})
+    pyqt.QtWidgets = qtwidgets
+    qgis.PyQt = pyqt
+    sys.modules["qgis"] = qgis
+    sys.modules["qgis.core"] = core
+    sys.modules["qgis.PyQt"] = pyqt
+    sys.modules["qgis.PyQt.QtCore"] = qtcore
+    sys.modules["qgis.PyQt.QtWidgets"] = qtwidgets
+
+    spec = importlib.util.spec_from_file_location(
+        "sfc_utils_under_test", ROOT / "helpers" / "utils.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
 
 
 class TestIssueRegressions(unittest.TestCase):
@@ -119,6 +172,30 @@ class TestSQLSafety(unittest.TestCase):
         self.assertEqual(mod.quote_literal("foo"), "'foo'")
         self.assertEqual(mod.quote_literal("it's"), "'it''s'")
 
+    def test_quote_literal_escapes_backslash(self):
+        """SNOW-3712090 / SNOW-3712092: Snowflake treats backslash as an escape
+        character in string literals, so quote_literal must double backslashes
+        to stop a trailing-backslash / \\' breakout of the single-quoted
+        literal."""
+        import importlib.util
+        spec = importlib.util.spec_from_file_location(
+            "helpers.sql", ROOT / "helpers" / "sql.py"
+        )
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+
+        # A lone backslash must be doubled.
+        self.assertEqual(mod.quote_literal("a\\b"), "'a\\\\b'")
+        # The classic breakout payload: \' UNION SELECT ... --
+        out = mod.quote_literal("\\' UNION SELECT CURRENT_ROLE() --")
+        self.assertEqual(out, "'\\\\'' UNION SELECT CURRENT_ROLE() --'")
+        # There must be no single backslash immediately before the closing
+        # quote (which Snowflake would read as an escaped, non-terminating
+        # quote). Every backslash in the interior must be doubled.
+        interior = out[1:-1]
+        self.assertNotIn("'", interior.replace("''", ""))
+        self.assertNotIn("\\", interior.replace("\\\\", ""))
+
     def test_quote_json_literal_for_parse_json_prefers_dollar_quotes(self):
         import importlib.util
         spec = importlib.util.spec_from_file_location(
@@ -144,6 +221,34 @@ class TestSQLSafety(unittest.TestCase):
         payload = '{"k":"contains $$ delimiter and it\'s ok"}'
         with self.assertRaises(ValueError):
             mod.quote_json_literal_for_parse_json(payload)
+
+    def test_predicate_has_statement_breakers(self):
+        """SNOW-3712086: the free-text WHERE-clause guard must flag comments,
+        statement terminators and set operators, while allowing a plain
+        boolean predicate."""
+        import importlib.util
+        spec = importlib.util.spec_from_file_location(
+            "helpers.sql", ROOT / "helpers" / "sql.py"
+        )
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+
+        for bad in [
+            "1=0 UNION ALL SELECT SSN FROM PROD.HR.EMPLOYEES --",
+            "POP > 1 ; DROP TABLE T",
+            "POP > 1 /* comment */",
+            "a INTERSECT SELECT 1",
+            "a EXCEPT SELECT 1",
+        ]:
+            self.assertTrue(
+                mod.predicate_has_statement_breakers(bad),
+                f"should flag: {bad!r}",
+            )
+        for ok in ["POP > 1000", "STATE = 'CA' AND POP >= 100", "", None]:
+            self.assertFalse(
+                mod.predicate_has_statement_breakers(ok),
+                f"should allow: {ok!r}",
+            )
 
     def test_qualified_table_name(self):
         import importlib.util
@@ -215,6 +320,475 @@ class TestSQLSafety(unittest.TestCase):
             encoding="utf-8"
         )
         self.assertIn("quote_identifier(", content_schema)
+
+
+class TestQuoteIdentifierInjection(unittest.TestCase):
+    """SNOW-3712084: quote_identifier() must never let an attacker-controlled
+    identifier break out of the quoted-identifier context.
+
+    Root cause: the original fast-path returned any value that merely started
+    and ended with a double quote VERBATIM, without verifying the interior was
+    a single well-formed quoted identifier. That allowed second-order SQL
+    injection through Snowflake object names and .qgs URI components
+    (SNOW-3712077 / 81 / 85 / 88 / 89 / 91 / 93 all flow through this helper).
+    """
+
+    @staticmethod
+    def _load_module():
+        import importlib.util
+        spec = importlib.util.spec_from_file_location(
+            "helpers.sql", ROOT / "helpers" / "sql.py"
+        )
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
+
+    @staticmethod
+    def _is_safe_identifier(out):
+        """A safe result is either a bare simple identifier or a single,
+        well-formed quoted identifier (all interior quotes doubled)."""
+        if re.match(r"^[A-Za-z_][A-Za-z0-9_$]*$", out):
+            return True
+        if len(out) >= 2 and out.startswith('"') and out.endswith('"'):
+            return '"' not in out[1:-1].replace('""', "")
+        return False
+
+    # Payloads lifted from the Mythos Zero findings; each begins and ends
+    # with a double quote but hides an un-doubled interior quote that breaks
+    # out of the identifier context (i.e. it is NOT a well-formed quoted
+    # identifier and must be re-escaped rather than passed through).
+    _MALICIOUS = [
+        '"X" AS SELECT * FROM SECRETS--"',
+        '"PUBLIC"."CUSTOMERS"(X INT)--"',
+        '"ALICE_LZ"."LOOT" AS SELECT * FROM PROD.SECRETS.KEYS--"',
+        '"X") FROM TABLE(GENERATOR(ROWCOUNT=>1e10)) --"',
+        '"X")) , (1) /*"',
+        '"G") IN (SELECT 1)) UNION ALL SELECT PASSWORD FROM USERS--"',
+    ]
+
+    def test_malicious_quoted_identifiers_are_neutralized(self):
+        mod = self._load_module()
+        for payload in self._MALICIOUS:
+            out = mod.quote_identifier(payload)
+            self.assertTrue(
+                self._is_safe_identifier(out),
+                f"quote_identifier failed to neutralize breakout payload "
+                f"{payload!r} -> {out!r}",
+            )
+            self.assertNotEqual(
+                out, payload,
+                f"quote_identifier passed malicious payload through "
+                f"verbatim: {payload!r}",
+            )
+
+    def test_wellformed_quoted_identifier_preserved(self):
+        """Legitimate, already-correctly-quoted identifiers must round-trip
+        unchanged so existing callers keep working."""
+        mod = self._load_module()
+        self.assertEqual(mod.quote_identifier('"already_quoted"'), '"already_quoted"')
+        self.assertEqual(mod.quote_identifier('"with""doubled"'), '"with""doubled"')
+        self.assertEqual(mod.quote_identifier('"col name"'), '"col name"')
+
+    def test_plain_identifiers_still_quote_correctly(self):
+        mod = self._load_module()
+        self.assertEqual(mod.quote_identifier("foo"), "foo")
+        self.assertEqual(mod.quote_identifier('foo"bar'), '"foo""bar"')
+
+
+class TestPhase2SQLInjectionCallSites(unittest.TestCase):
+    """Phase 2: individual call sites that fed attacker-controlled values into
+    SQL without routing them through the centralized quoting helpers."""
+
+    def test_get_type_from_table_geo_column_quotes_from_clause(self):
+        """SNOW-3712081: the table_name forwarded as the FROM clause must be
+        quoted, otherwise a stored TABLE_NAME can splice raw SQL into FROM."""
+        content = (ROOT / "helpers" / "data_base.py").read_text(encoding="utf-8")
+        idx = content.index("def get_type_from_table_geo_column(")
+        next_def = content.index("\ndef ", idx + 1)
+        body = content[idx:next_def]
+        self.assertIn("from_clause=quote_identifier(table_name)", body)
+        self.assertNotIn("from_clause=table_name", body)
+
+    def test_geometry_type_escaped_in_extent_query(self):
+        """SNOW-3712085: _geometry_type comes from the (project-file) URI and
+        must be escaped as a literal, not interpolated inside raw quotes."""
+        content = (ROOT / "providers" / "sf_vector_data_provider.py").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("quote_literal(self._geometry_type)", content)
+        self.assertNotIn("ILIKE '{self._geometry_type}'", content)
+
+    def test_geometry_type_escaped_in_feature_iterator(self):
+        """SNOW-3712085: same URI-controlled value reused in the iterator's
+        inner WHERE IN (...) list must be escaped via quote_literal."""
+        content = (ROOT / "providers" / "sf_feature_iterator.py").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("quote_literal(self._provider._geometry_type)", content)
+        self.assertNotIn("IN ('{self._provider._geometry_type}'", content)
+
+
+class TestPhase3PredicateInjection(unittest.TestCase):
+    """Phase 3: raw SQL predicates / QGIS expressions must not reach Snowflake
+    verbatim (SNOW-3712078 / SNOW-3712093 / SNOW-3712086)."""
+
+    def test_expression_compiler_is_fail_safe(self):
+        content = (ROOT / "helpers" / "expression_compiler.py").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("QgsSqlExpressionCompiler", content)
+        # Only fully-compiled expressions are emitted; everything else -> None.
+        self.assertIn("QgsSqlExpressionCompiler.Complete", content)
+        self.assertIn("def compile_expression_to_sql(", content)
+        # Values/identifiers routed through the safe helpers.
+        self.assertIn("quote_identifier", content)
+        self.assertIn("quote_literal", content)
+
+    def test_feature_iterator_compiles_filter_expression(self):
+        """SNOW-3712078: the iterator must compile the filter expression and
+        must NOT run the old raw validation query or append raw expression."""
+        content = (ROOT / "providers" / "sf_feature_iterator.py").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("from ..helpers.expression_compiler import compile_expression_to_sql", content)
+        self.assertIn("compile_expression_to_sql(", content)
+        # The raw-text pushdown patterns must be gone.
+        self.assertNotIn("where_clause_list.append(expression)", content)
+        self.assertNotIn('.replace(\'"\', "")', content)
+
+    def test_provider_subset_string_is_compiled(self):
+        """SNOW-3712093: setSubsetString must compile/validate rather than
+        execute the raw predicate as a probe."""
+        content = (ROOT / "providers" / "sf_vector_data_provider.py").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("compile_expression_to_sql(", content)
+        idx = content.index("def setSubsetString(")
+        next_def = content.index("\n    def ", idx + 1)
+        body = content[idx:next_def]
+        self.assertIn("compile_expression_to_sql(subsetstring", body)
+        self.assertNotIn("WHERE {subsetstring} LIMIT 0", body)
+
+    def test_import_where_clause_is_guarded(self):
+        """SNOW-3712086: the free-text WHERE clause must be validated before it
+        is concatenated into the SELECT."""
+        content = (ROOT / "processing" / "import_from_snowflake.py").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("predicate_has_statement_breakers", content)
+        self.assertIn("QgsProcessingException", content)
+        guard_idx = content.index("predicate_has_statement_breakers(where)")
+        append_idx = content.index('sql += f" WHERE {where}"')
+        self.assertLess(
+            guard_idx, append_idx,
+            "WHERE clause must be validated before being appended",
+        )
+
+
+class TestPhase4ProjectFileTrust(unittest.TestCase):
+    """Phase 4: values restored verbatim from an (untrusted) .qgs/.qgz project
+    must be re-validated before they can cause harm."""
+
+    def test_sql_query_layer_is_row_capped(self):
+        """SNOW-3712076: the custom sql_query layer branch must also compute
+        _is_limited_unordered (row cap), not leave it at the default False."""
+        content = (ROOT / "providers" / "sf_vector_data_provider.py").read_text(
+            encoding="utf-8"
+        )
+        start = content.index("if self._sql_query and not self._table_name:")
+        end = content.index("self.get_geometry_column()", start)
+        block = content[start:end]
+        # Both the sql_query branch and the table branch must size-check.
+        self.assertEqual(
+            block.count("check_from_clause_exceeds_size"), 2,
+            "sql_query branch must also probe size via check_from_clause_exceeds_size",
+        )
+        self.assertIn("SNOW-3712076", block)
+
+    def test_iterator_close_releases_cursor(self):
+        """SNOW-3712076: close() must release the server-side cursor."""
+        content = (ROOT / "providers" / "sf_feature_iterator.py").read_text(
+            encoding="utf-8"
+        )
+        idx = content.index("def close(self)")
+        body = content[idx:idx + 500]
+        self.assertIn("result.close()", body)
+        self.assertIn("self._result = None", body)
+
+    def test_capabilities_gate_on_limited_unordered(self):
+        """SNOW-3712082: edit/SelectAtId capabilities must be withheld when the
+        result set is a random-sampled/unordered set (unstable feature ids)."""
+        content = (ROOT / "providers" / "sf_vector_data_provider.py").read_text(
+            encoding="utf-8"
+        )
+        idx = content.index("def capabilities(self)")
+        next_def = content.index("\n    def ", idx + 1)
+        body = content[idx:next_def]
+        self.assertIn("self._is_limited_unordered", body)
+
+    def test_capabilities_revalidate_primary_key(self):
+        """SNOW-3712083: capabilities must re-validate the URI primary key
+        uniqueness before granting edit capabilities."""
+        content = (ROOT / "providers" / "sf_vector_data_provider.py").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("def _validate_primary_key(self)", content)
+        self.assertIn("get_declared_primary_key", content)
+        self.assertIn("check_column_has_duplicates", content)
+        idx = content.index("def capabilities(self)")
+        next_def = content.index("\n    def ", idx + 1)
+        body = content[idx:next_def]
+        self.assertIn("_validate_primary_key()", body)
+
+
+class TestPhase4AuthcfgUri(unittest.TestCase):
+    """SNOW-3712094: the connection alias must be hidden behind an authcfg=
+    token in persisted URIs, and resolved back on load."""
+
+    def _load_utils(self):
+        return _load_helpers_utils(self)
+
+    def test_decode_uri_supports_legacy_connection_name(self):
+        mod = self._load_utils()
+        params = mod.decodeUri("connection_name=myconn table_name=T srid=4326")
+        self.assertEqual(params.get("connection_name"), "myconn")
+
+    def test_decode_uri_resolves_authcfg_to_connection_name(self):
+        mod = self._load_utils()
+        mod.resolve_authcfg_connection_name = (
+            lambda cid: "resolved_conn" if cid == "ABC1234" else None
+        )
+        params = mod.decodeUri("authcfg=ABC1234 table_name=T srid=4326")
+        self.assertEqual(params.get("authcfg"), "ABC1234")
+        self.assertEqual(params.get("connection_name"), "resolved_conn")
+
+    def test_decode_uri_authcfg_unresolvable_leaves_no_connection(self):
+        # A project opened on a foreign machine: the id does not resolve, so no
+        # connection_name is injected -> parse_uri will later reject it.
+        mod = self._load_utils()
+        mod.resolve_authcfg_connection_name = lambda cid: None
+        params = mod.decodeUri("authcfg=NOPE table_name=T srid=4326")
+        self.assertNotIn("connection_name", params)
+
+    def test_connection_uri_token_prefers_authcfg(self):
+        mod = self._load_utils()
+        mod.get_or_create_connection_authcfg = lambda name: "XYZ7890"
+        self.assertEqual(mod.connection_uri_token("myconn"), "authcfg=XYZ7890")
+
+    def test_connection_uri_token_falls_back_to_connection_name(self):
+        mod = self._load_utils()
+        mod.get_or_create_connection_authcfg = lambda name: None
+        self.assertEqual(
+            mod.connection_uri_token("myconn"), "connection_name=myconn"
+        )
+
+    def test_datasource_uri_honors_expand_auth_config(self):
+        content = (ROOT / "providers" / "sf_vector_data_provider.py").read_text(
+            encoding="utf-8"
+        )
+        idx = content.index("def dataSourceUri(self")
+        next_def = content.index("\n    def ", idx + 1)
+        body = content[idx:next_def]
+        self.assertIn("expandAuthConfig", body)
+        self.assertIn("authcfg=", body)
+        self.assertIn("get_or_create_connection_authcfg", body)
+        self.assertIn("_replace_connection_token", body)
+        # The redacted branch must be guarded by the expandAuthConfig flag
+        # rather than unconditionally returning the alias-bearing uri.
+        self.assertIn("if expandAuthConfig:", body)
+
+    def test_uri_builders_use_redacted_token(self):
+        task = (ROOT / "tasks" / "sf_convert_column_to_layer_task.py").read_text(
+            encoding="utf-8"
+        )
+        meta = (ROOT / "providers" / "sf_metadata_provider.py").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("connection_uri_token(", task)
+        self.assertIn("connection_uri_token(", meta)
+
+
+class TestPhase5Hardening(unittest.TestCase):
+    """Phase 5: cleartext credentials, forced-SMB rich text, arbitrary SQL."""
+
+    def test_no_geom_dialog_forces_plain_text(self):
+        """SNOW-3712087: the server-controlled table name must be shown as plain
+        text so a <img src=UNC> name cannot trigger an SMB/NTLM leak."""
+        content = (ROOT / "entities" / "sf_data_item.py").read_text(
+            encoding="utf-8"
+        )
+        idx = content.index('if self.item_type == "table_no_geom":')
+        block = content[idx:idx + 900]
+        self.assertIn("setTextFormat(Qt.TextFormat.PlainText)", block)
+        # The vulnerable auto-format static call must be gone from this branch.
+        self.assertNotIn("QMessageBox.information(", block)
+
+    def test_dialog_skips_cleartext_password_when_encrypted(self):
+        """SNOW-3712079: the dialog must not capture the Basic-tab password when
+        the encrypted Configurations tab is selected."""
+        content = (
+            ROOT / "dialogs" / "sf_connection_string_dialog.py"
+        ).read_text(encoding="utf-8")
+        self.assertIn(
+            'if is_default_auth and not config_tab_selected:', content
+        )
+
+    def test_set_connection_settings_clears_password_when_encrypted(self):
+        """SNOW-3712079: saving an encrypted Default-Auth connection (no
+        password provided) must remove any stale cleartext password rather than
+        crash or leave it behind."""
+        mod = _load_helpers_utils(self)
+
+        class _FakeSettings:
+            def __init__(self):
+                self.values = {}
+                self.removed = []
+
+            def beginGroup(self, *_):
+                pass
+
+            def endGroup(self):
+                pass
+
+            def sync(self):
+                pass
+
+            def setValue(self, key, value):
+                self.values[key] = value
+
+            def remove(self, key):
+                self.removed.append(key)
+
+        fake = _FakeSettings()
+        mod.get_qsettings = lambda: fake
+        mod.set_connection_settings({
+            "name": "conn1",
+            "warehouse": "WH",
+            "account": "ACC",
+            "database": "DB",
+            "username": "user",
+            "connection_type": "Default Authentication",
+            "password_encrypted": True,
+            "config_id": "abc123",
+        })
+        self.assertNotIn("password", fake.values)
+        self.assertIn("password", fake.removed)
+
+    def test_set_connection_settings_writes_password_when_plaintext(self):
+        """Guard rail: legacy plaintext Default-Auth still stores the password."""
+        mod = _load_helpers_utils(self)
+
+        class _FakeSettings:
+            def __init__(self):
+                self.values = {}
+                self.removed = []
+
+            def beginGroup(self, *_):
+                pass
+
+            def endGroup(self):
+                pass
+
+            def sync(self):
+                pass
+
+            def setValue(self, key, value):
+                self.values[key] = value
+
+            def remove(self, key):
+                self.removed.append(key)
+
+        fake = _FakeSettings()
+        mod.get_qsettings = lambda: fake
+        mod.set_connection_settings({
+            "name": "conn1",
+            "warehouse": "WH",
+            "account": "ACC",
+            "database": "DB",
+            "username": "user",
+            "connection_type": "Default Authentication",
+            "password_encrypted": False,
+            "password": "s3cret",
+        })
+        self.assertEqual(fake.values.get("password"), "s3cret")
+
+    def _load_execute_sql(self, iface_value):
+        import sys
+        import types
+        import importlib.util
+
+        names = (
+            "qgis", "qgis.core", "qgis.PyQt", "qgis.PyQt.QtCore",
+            "qgis.PyQt.QtGui", "qgis.utils",
+        )
+        saved = {n: sys.modules.get(n) for n in names}
+
+        def _restore():
+            for n, prev in saved.items():
+                if prev is None:
+                    sys.modules.pop(n, None)
+                else:
+                    sys.modules[n] = prev
+        self.addCleanup(_restore)
+
+        qgis = types.ModuleType("qgis")
+        core = types.ModuleType("qgis.core")
+        for nm in (
+            "QgsProcessingAlgorithm", "QgsProcessingParameterString",
+            "QgsProcessingOutputString",
+        ):
+            setattr(core, nm, type(nm, (), {}))
+        core.QgsProcessingException = type(
+            "QgsProcessingException", (Exception,), {}
+        )
+        qgis.core = core
+        pyqt = types.ModuleType("qgis.PyQt")
+        qtcore = types.ModuleType("qgis.PyQt.QtCore")
+        qtcore.QCoreApplication = type("QCoreApplication", (), {})
+        qtgui = types.ModuleType("qgis.PyQt.QtGui")
+        qtgui.QIcon = type("QIcon", (), {})
+        pyqt.QtCore = qtcore
+        pyqt.QtGui = qtgui
+        qgis.PyQt = pyqt
+        utils = types.ModuleType("qgis.utils")
+        utils.iface = iface_value
+        sys.modules["qgis"] = qgis
+        sys.modules["qgis.core"] = core
+        sys.modules["qgis.PyQt"] = pyqt
+        sys.modules["qgis.PyQt.QtCore"] = qtcore
+        sys.modules["qgis.PyQt.QtGui"] = qtgui
+        sys.modules["qgis.utils"] = utils
+
+        spec = importlib.util.spec_from_file_location(
+            "sfc_execute_sql_under_test", ROOT / "processing" / "execute_sql.py"
+        )
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
+
+    def test_execute_sql_headless_proceeds_without_prompt(self):
+        """SNOW-3712080: headless (no iface) runs are user-initiated and proceed."""
+        mod = self._load_execute_sql(iface_value=None)
+        alg = mod.ExecuteSQLAlgorithm()
+        self.assertTrue(alg._confirm_execution("conn", "SELECT 1"))
+
+    def test_execute_sql_requires_confirmation_before_execution(self):
+        """SNOW-3712080: the algorithm must gate execution on _confirm_execution
+        and abort with QgsProcessingException when declined."""
+        content = (ROOT / "processing" / "execute_sql.py").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("FlagNoThreading", content)
+        idx = content.index("def processAlgorithm(")
+        body = content[idx:]
+        confirm_pos = body.index("_confirm_execution(")
+        exec_pos = body.index("mgr.execute_query(")
+        self.assertLess(
+            confirm_pos, exec_pos,
+            "confirmation must happen before the SQL is executed",
+        )
+        self.assertIn("QgsProcessingException(", body)
+        self.assertIn("setTextFormat(Qt.TextFormat.PlainText)", content)
 
 
 class TestProviderLifecycle(unittest.TestCase):
@@ -999,6 +1573,13 @@ class TestSpatialFilterPushdownGuard(unittest.TestCase):
             "qgis_snowflake_connector.helpers.sql"
         )
         helpers_sql.quote_identifier = lambda n: n
+        helpers_sql.quote_literal = lambda v: "'" + str(v).replace("'", "''") + "'"
+        helpers_expression_compiler = types.ModuleType(
+            "qgis_snowflake_connector.helpers.expression_compiler"
+        )
+        helpers_expression_compiler.compile_expression_to_sql = (
+            lambda expr, fields: None
+        )
         helpers_mappings = types.ModuleType(
             "qgis_snowflake_connector.helpers.mappings"
         )
@@ -1013,6 +1594,7 @@ class TestSpatialFilterPushdownGuard(unittest.TestCase):
         sf_feature_source.SFFeatureSource = type("SFFeatureSource", (), {})
         for mod in (
             plugin_pkg, helpers_pkg, helpers_limits, helpers_sql,
+            helpers_expression_compiler,
             helpers_mappings, providers_pkg, sf_feature_source,
         ):
             sys.modules.setdefault(mod.__name__, mod)

--- a/test/test_issue_regressions.py
+++ b/test/test_issue_regressions.py
@@ -58,6 +58,324 @@ def _load_helpers_utils(testcase):
     return mod
 
 
+# --- Fake QgsExpression AST node classes for the expression compiler tests ---
+# These duck-type the PyQGIS node API used by helpers/expression_compiler.py.
+# The SAME class objects are injected into the stubbed qgis.core so the
+# compiler's isinstance() checks match instances built here.
+
+
+class _FakeColumnRef:
+    def __init__(self, name):
+        self._name = name
+
+    def name(self):
+        return self._name
+
+
+class _FakeLiteral:
+    def __init__(self, value):
+        self._value = value
+
+    def value(self):
+        return self._value
+
+
+class _FakeBinaryOperator:
+    # Enum values mirror QgsExpressionNodeBinaryOperator (exact values are not
+    # important as long as they are consistent between here and the compiler).
+    boOr = 0
+    boAnd = 1
+    boEQ = 2
+    boNE = 3
+    boLE = 4
+    boGE = 5
+    boLT = 6
+    boGT = 7
+    boRegexp = 8
+    boLike = 9
+    boNotLike = 10
+    boILike = 11
+    boNotILike = 12
+    boIs = 13
+    boIsNot = 14
+    boPlus = 15
+    boMinus = 16
+    boMul = 17
+    boDiv = 18
+
+    def __init__(self, op, left, right):
+        self._op = op
+        self._left = left
+        self._right = right
+
+    def op(self):
+        return self._op
+
+    def opLeft(self):
+        return self._left
+
+    def opRight(self):
+        return self._right
+
+
+class _FakeUnaryOperator:
+    uoNot = 0
+    uoMinus = 1
+
+    def __init__(self, op, operand):
+        self._op = op
+        self._operand = operand
+
+    def op(self):
+        return self._op
+
+    def operand(self):
+        return self._operand
+
+
+class _FakeNodeList:
+    def __init__(self, nodes):
+        self._nodes = nodes
+
+    def list(self):
+        return self._nodes
+
+
+class _FakeInOperator:
+    def __init__(self, node, members, is_not=False):
+        self._node = node
+        self._list = _FakeNodeList(members)
+        self._is_not = is_not
+
+    def node(self):
+        return self._node
+
+    def list(self):
+        return self._list
+
+    def isNotIn(self):
+        return self._is_not
+
+
+class _FakeExpression:
+    def __init__(self, text):
+        self._text = text
+
+    def hasParserError(self):
+        return False
+
+    def rootNode(self):
+        return None
+
+
+class _FakeField:
+    def __init__(self, name):
+        self._name = name
+
+    def name(self):
+        return self._name
+
+
+class _FakeFields:
+    """Case-insensitive field lookup mirroring QgsFields."""
+
+    def __init__(self, names):
+        self._names = list(names)
+
+    def lookupField(self, name):
+        for idx, existing in enumerate(self._names):
+            if existing.lower() == name.lower():
+                return idx
+        return -1
+
+    def at(self, idx):
+        return _FakeField(self._names[idx])
+
+
+class _FakeUnsupportedNode:
+    """A node type outside the whitelist (e.g. a function)."""
+
+
+def _load_expression_compiler(testcase):
+    """Load the real helpers/expression_compiler.py against a stub qgis.core
+    that exposes the AST node classes (but NOT QgsSqlExpressionCompiler).
+
+    This exercises the module's real import list, so it guards against the
+    plugin-load crash that occurred when the module depended on the
+    unavailable QgsSqlExpressionCompiler binding.
+    """
+    import sys
+    import types
+    import importlib.util
+
+    names = ("qgis", "qgis.core", "helpers", "helpers.sql",
+             "helpers.expression_compiler")
+    saved = {n: sys.modules.get(n) for n in names}
+
+    def _restore():
+        for n, prev in saved.items():
+            if prev is None:
+                sys.modules.pop(n, None)
+            else:
+                sys.modules[n] = prev
+    testcase.addCleanup(_restore)
+
+    qgis = types.ModuleType("qgis")
+    core = types.ModuleType("qgis.core")
+    core.QgsExpression = _FakeExpression
+    core.QgsExpressionNodeBinaryOperator = _FakeBinaryOperator
+    core.QgsExpressionNodeColumnRef = _FakeColumnRef
+    core.QgsExpressionNodeInOperator = _FakeInOperator
+    core.QgsExpressionNodeLiteral = _FakeLiteral
+    core.QgsExpressionNodeUnaryOperator = _FakeUnaryOperator
+    core.QgsFields = _FakeFields
+    qgis.core = core
+    sys.modules["qgis"] = qgis
+    sys.modules["qgis.core"] = core
+
+    # Register a "helpers" package rooted at the real folder so the module's
+    # relative "from .sql import ..." resolves to the real (pure-Python) sql.py.
+    helpers_pkg = types.ModuleType("helpers")
+    helpers_pkg.__path__ = [str(ROOT / "helpers")]
+    sys.modules["helpers"] = helpers_pkg
+    sys.modules.pop("helpers.sql", None)
+
+    spec = importlib.util.spec_from_file_location(
+        "helpers.expression_compiler", ROOT / "helpers" / "expression_compiler.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["helpers.expression_compiler"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class TestExpressionCompilerCompilation(unittest.TestCase):
+    """Behavioral + import-safety tests for the pure-Python AST compiler."""
+
+    def setUp(self):
+        self.mod = _load_expression_compiler(self)
+        self.fields = _FakeFields(["POP", "NAME", "ID"])
+
+    def _compile(self, node):
+        return self.mod._compile_node(node, self.fields)
+
+    def test_module_imports_without_qgs_sql_expression_compiler(self):
+        # The mere fact setUp() loaded the module under a qgis.core that does
+        # NOT define QgsSqlExpressionCompiler proves the import bug is gone.
+        self.assertTrue(hasattr(self.mod, "compile_expression_to_sql"))
+
+    def test_equality_compiles_with_quoting(self):
+        node = _FakeBinaryOperator(
+            _FakeBinaryOperator.boEQ, _FakeColumnRef("POP"), _FakeLiteral(1000)
+        )
+        self.assertEqual(self._compile(node), "(POP = 1000)")
+
+    def test_and_of_predicates_compiles(self):
+        node = _FakeBinaryOperator(
+            _FakeBinaryOperator.boAnd,
+            _FakeBinaryOperator(
+                _FakeBinaryOperator.boGT, _FakeColumnRef("POP"), _FakeLiteral(1000)
+            ),
+            _FakeBinaryOperator(
+                _FakeBinaryOperator.boILike,
+                _FakeColumnRef("NAME"),
+                _FakeLiteral("A%"),
+            ),
+        )
+        self.assertEqual(
+            self._compile(node), "((POP > 1000) AND (NAME ILIKE 'A%'))"
+        )
+
+    def test_or_of_predicates_compiles(self):
+        node = _FakeBinaryOperator(
+            _FakeBinaryOperator.boOr,
+            _FakeBinaryOperator(
+                _FakeBinaryOperator.boEQ, _FakeColumnRef("ID"), _FakeLiteral(1)
+            ),
+            _FakeBinaryOperator(
+                _FakeBinaryOperator.boEQ, _FakeColumnRef("ID"), _FakeLiteral(2)
+            ),
+        )
+        self.assertEqual(
+            self._compile(node), "((ID = 1) OR (ID = 2))"
+        )
+
+    def test_in_operator_compiles(self):
+        node = _FakeInOperator(
+            _FakeColumnRef("ID"), [_FakeLiteral(1), _FakeLiteral(2)]
+        )
+        self.assertEqual(self._compile(node), "(ID IN (1, 2))")
+
+    def test_not_in_operator_compiles(self):
+        node = _FakeInOperator(
+            _FakeColumnRef("ID"), [_FakeLiteral(1)], is_not=True
+        )
+        self.assertEqual(self._compile(node), "(ID NOT IN (1))")
+
+    def test_not_unary_compiles(self):
+        node = _FakeUnaryOperator(
+            _FakeUnaryOperator.uoNot,
+            _FakeBinaryOperator(
+                _FakeBinaryOperator.boEQ, _FakeColumnRef("POP"), _FakeLiteral(1)
+            ),
+        )
+        self.assertEqual(self._compile(node), "(NOT (POP = 1))")
+
+    def test_string_literal_is_escaped(self):
+        node = _FakeBinaryOperator(
+            _FakeBinaryOperator.boEQ,
+            _FakeColumnRef("NAME"),
+            _FakeLiteral("x'); DROP TABLE t;--"),
+        )
+        compiled = self._compile(node)
+        self.assertEqual(compiled, "(NAME = 'x''); DROP TABLE t;--')")
+
+    def test_null_and_bool_literals(self):
+        is_null = _FakeBinaryOperator(
+            _FakeBinaryOperator.boIs, _FakeColumnRef("NAME"), _FakeLiteral(None)
+        )
+        self.assertEqual(self._compile(is_null), "(NAME IS NULL)")
+        is_true = _FakeBinaryOperator(
+            _FakeBinaryOperator.boEQ, _FakeColumnRef("ID"), _FakeLiteral(True)
+        )
+        self.assertEqual(self._compile(is_true), "(ID = TRUE)")
+
+    def test_unknown_column_returns_none(self):
+        node = _FakeBinaryOperator(
+            _FakeBinaryOperator.boEQ, _FakeColumnRef("SECRET"), _FakeLiteral(1)
+        )
+        self.assertIsNone(self._compile(node))
+
+    def test_unsupported_binary_operator_returns_none(self):
+        node = _FakeBinaryOperator(
+            _FakeBinaryOperator.boPlus, _FakeColumnRef("POP"), _FakeLiteral(1)
+        )
+        self.assertIsNone(self._compile(node))
+
+    def test_unsupported_node_type_returns_none(self):
+        self.assertIsNone(self._compile(_FakeUnsupportedNode()))
+
+    def test_unary_minus_returns_none(self):
+        node = _FakeUnaryOperator(
+            _FakeUnaryOperator.uoMinus, _FakeLiteral(1)
+        )
+        self.assertIsNone(self._compile(node))
+
+    def test_in_with_uncompilable_member_returns_none(self):
+        node = _FakeInOperator(
+            _FakeColumnRef("ID"), [_FakeLiteral(1), _FakeUnsupportedNode()]
+        )
+        self.assertIsNone(self._compile(node))
+
+    def test_compile_expression_to_sql_guards_empty_and_none(self):
+        self.assertIsNone(
+            self.mod.compile_expression_to_sql("", self.fields)
+        )
+        self.assertIsNone(
+            self.mod.compile_expression_to_sql("x", None)
+        )
+
+
 class TestIssueRegressions(unittest.TestCase):
     def test_utils_uses_importlib_metadata(self):
         content = (ROOT / "helpers" / "utils.py").read_text(encoding="utf-8")
@@ -439,9 +757,11 @@ class TestPhase3PredicateInjection(unittest.TestCase):
         content = (ROOT / "helpers" / "expression_compiler.py").read_text(
             encoding="utf-8"
         )
-        self.assertIn("QgsSqlExpressionCompiler", content)
-        # Only fully-compiled expressions are emitted; everything else -> None.
-        self.assertIn("QgsSqlExpressionCompiler.Complete", content)
+        # QgsSqlExpressionCompiler is NOT exposed in PyQGIS; the module must not
+        # depend on it (that dependency crashed plugin load).
+        self.assertNotIn("QgsSqlExpressionCompiler", content)
+        # Compilation walks the QgsExpression AST and fails closed to None.
+        self.assertIn("rootNode()", content)
         self.assertIn("def compile_expression_to_sql(", content)
         # Values/identifiers routed through the safe helpers.
         self.assertIn("quote_identifier", content)

--- a/test/test_issue_regressions.py
+++ b/test/test_issue_regressions.py
@@ -115,7 +115,10 @@ class TestIssueRegressions(unittest.TestCase):
         content = (ROOT / "providers" / "sf_data_source_provider.py").read_text(
             encoding="utf-8"
         )
-        self.assertIn("qgsField.setSubType(subType)", content)
+        # The subtype is preserved via the version-compatible helper
+        # (issue #120): create_qgs_field applies setSubType internally.
+        self.assertIn("sub_type=subType", content)
+        self.assertIn("create_qgs_field(", content)
 
     def test_export_blocks_same_snowflake_table(self):
         """Export must refuse when target table matches the input layer's
@@ -1470,6 +1473,62 @@ class TestGitHubIssuesFixes(unittest.TestCase):
         content = (ROOT / "entities" / "sf_data_item.py").read_text(encoding="utf-8")
         self.assertIn("No accessible tables found", content)
         self.assertIn("QgsErrorItem", content)
+
+
+class TestOpenIssueFixes(unittest.TestCase):
+    """Fixes for the open tracker issues #120, #119 and #118."""
+
+    def test_qgsfield_helper_is_version_compatible(self):
+        """#120: QgsField must be built through a helper that falls back to
+        QVariant.Type on QGIS < 3.38 (the QMetaType.Type constructor is only
+        available from 3.38)."""
+        content = (ROOT / "helpers" / "mappings.py").read_text(encoding="utf-8")
+        self.assertIn("def create_qgs_field(", content)
+        self.assertIn("QGIS_VERSION_INT", content)
+        self.assertIn("33800", content)
+        self.assertIn("QVariant.Type(int(metatype))", content)
+
+    def test_qgsfield_construction_sites_use_helper(self):
+        """#120: every QgsField construction that takes a QMetaType.Type must
+        route through create_qgs_field."""
+        for rel in [
+            ("providers", "sf_data_source_provider.py"),
+            ("providers", "sf_vector_data_provider.py"),
+            ("processing", "import_from_snowflake.py"),
+            ("helpers", "layer_creation.py"),
+        ]:
+            content = (ROOT.joinpath(*rel)).read_text(encoding="utf-8")
+            self.assertIn(
+                "create_qgs_field(", content,
+                f"{'/'.join(rel)} must build fields via create_qgs_field",
+            )
+
+    def test_feature_iterator_initializes_expression_unconditionally(self):
+        """#119: self._expression must be set before the features-cached guard
+        so nextFeatureFilterExpression never hits an unset attribute."""
+        content = (ROOT / "providers" / "sf_feature_iterator.py").read_text(
+            encoding="utf-8"
+        )
+        init_expr = content.index('self._expression = ""')
+        guard = content.index("if not self._provider._features_loaded:")
+        self.assertLess(
+            init_expr, guard,
+            "self._expression must be initialized before the "
+            "_features_loaded guard",
+        )
+
+    def test_data_item_handles_table_group_and_no_geom(self):
+        """#118: expanding 'Tables (no geometry)' must not fall through to
+        _get_query_metadata with an unhandled item_type."""
+        content = (ROOT / "entities" / "sf_data_item.py").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("def create_table_group_item(", content)
+        self.assertIn('elif self.item_type == "table_group":', content)
+        self.assertIn('if self.item_type in ("field", "table_no_geom"):', content)
+        # Children are built lazily from a stashed list, not pre-added.
+        self.assertIn("group_item.non_geo_tables = sorted(non_geo_tables)", content)
+        self.assertNotIn("group_item.addChildItem(", content)
 
 
 class TestSpatialFilterPushdownGuard(unittest.TestCase):

--- a/test/test_issue_regressions.py
+++ b/test/test_issue_regressions.py
@@ -1971,10 +1971,19 @@ class TestSpatialFilterPushdownGuard(unittest.TestCase):
             "qgis_snowflake_connector.providers.sf_feature_source"
         )
         sf_feature_source.SFFeatureSource = type("SFFeatureSource", (), {})
+        managers_pkg = types.ModuleType(
+            "qgis_snowflake_connector.managers"
+        )
+        managers_pkg.__path__ = [str(ROOT / "managers")]
+        sf_connection_manager = types.ModuleType(
+            "qgis_snowflake_connector.managers.sf_connection_manager"
+        )
+        sf_connection_manager.build_op_tag = lambda *a, **k: ""
         for mod in (
             plugin_pkg, helpers_pkg, helpers_limits, helpers_sql,
             helpers_expression_compiler,
             helpers_mappings, providers_pkg, sf_feature_source,
+            managers_pkg, sf_connection_manager,
         ):
             sys.modules.setdefault(mod.__name__, mod)
 


### PR DESCRIPTION
## Summary

Merges the current `dev` work into `main`. It contains one pre-existing infrastructure workstream and the SNOW-3712074 security remediation, organized as four granular commits.

### Commits
1. **Connection-pool telemetry, cooperative cancel, and temporal range** — `build_op_tag()`, per-connection schema/QUERY_TAG caching, per-thread cursor cancellation, task `cancel()` hooks, and timestamp-column-driven fixed temporal range.
2. **SQL identifier/literal/expression injection + project-file trust hardening** — fixed `quote_identifier()`/`quote_literal()`, WHERE-clause token guard, a fail-safe expression compiler for `filterExpression`/`subsetString`, `authcfg=` URI redaction (with `expandAuthConfig` support), `sql_query` row-cap, edit/`SelectAtId` gating on unstable feature ids, primary-key uniqueness re-validation, and feature-iterator cursor cleanup.
3. **Credential + UI hardening** — no cleartext password when the encrypted tab is used (and stale plaintext removed), plain-text "No Geometry Column" dialog to block forced-SMB/NTLM leaks, and an explicit confirmation gate before `executesql` runs arbitrary SQL in the GUI.
4. **Regression tests** — source-level and behavioral tests for all of the above.

Findings covered: the 19 sub-issues of SNOW-3712074 (identifier/literal/expression injection, `.qgs`/URI trust boundary, OOM/DoS row caps, cleartext password, NTLM/rich-text, arbitrary-SQL processing algorithm).

## Test plan
- [x] `python test/test_issue_regressions.py` — 123 tests; only the pre-existing `QSettings` mock error remains (unrelated environment gap).
- [x] `py_compile` + `flake8 --select=E9,F63,F7,F82,F401,F811` clean on all touched modules.
- [ ] Runtime-verify in a real QGIS session: the `authcfg` layer round-trip (save/reopen project, confirm no `connection_name=` in the `.qgs`) and the `executesql` GUI confirmation prompt.

Made with [Cursor](https://cursor.com)