### PR TITLE
Fix plugin packaging folder name (v1.0.14)

### DIFF
--- a/metadata.txt
+++ b/metadata.txt
@@ -8,7 +8,7 @@ qgisMinimumVersion=3.34.1
 qgisMaximumVersion=4.99
 supportsQt6=True
 description=This package includes the Snowflake Connector for QGIS.
-version=1.0.13
+version=1.0.14
 author=Snowflake Inc.
 email=erick.cuberojimenez@snowflake.com
 
@@ -21,7 +21,11 @@ repository=https://github.com/snowflakedb/qgis-snowflake-connector/
 # Recommended items:
 
 hasProcessingProvider=yes
-changelog=1.0.13 - Fix SNOW-3712094 auth-config reuse: load the stored config
+changelog=1.0.14 - Fix packaging: install under the valid Python package name
+ qgis_snowflake_connector (underscore) instead of the hyphenated folder, which
+ QGIS could not import consistently and caused a ModuleNotFoundError in
+ SFFeatureSource when loading or rendering a layer.
+ 1.0.13 - Fix SNOW-3712094 auth-config reuse: load the stored config
  with full=True so the connection alias is matched and the existing authcfg id
  is reused, instead of leaking a new QGIS auth config on every layer creation.
  1.0.12 - Fix plugin load failure ("cannot import name

--- a/scripts/build_package.py
+++ b/scripts/build_package.py
@@ -17,7 +17,7 @@ import tempfile
 import zipfile
 from pathlib import Path
 
-PLUGIN_DIR_NAME = "qgis-snowflake-connector"
+PLUGIN_DIR_NAME = "qgis_snowflake_connector"
 
 EXCLUDE_ALWAYS = {
     ".git",


### PR DESCRIPTION
## Summary
- Package the plugin under its canonical Python-valid folder name `qgis_snowflake_connector` (underscore), matching `pb_tool.cfg` and `Makefile`, instead of the hyphenated `qgis-snowflake-connector`.
- The hyphenated name is not a valid Python identifier, so QGIS normalized it inconsistently and the deferred relative import in `SFFeatureSource` raised `ModuleNotFoundError: No module named 'qgis_snowflake_connector.providers.sf_vector_data_provider'` when a layer's feature source was requested for iteration/rendering.
- Bump to v1.0.14 with a changelog entry.

## Changes
- `scripts/build_package.py`: `PLUGIN_DIR_NAME` -> `qgis_snowflake_connector`.
- `metadata.txt`: version 1.0.14 + changelog.

## Test plan
- [x] `python scripts/build_package.py` produces `qgis_snowflake_connector-1.0.14.zip` with a single top-level `qgis_snowflake_connector/` folder.
- [ ] Reinstall in QGIS and confirm loading/rendering a Snowflake layer no longer raises ModuleNotFoundError.

Made with [Cursor](https://cursor.com)