### PR TITLE
Fix layer-load ModuleNotFoundError; restore hyphen package folder (1.0.15)

### DIFF
--- a/metadata.txt
+++ b/metadata.txt
@@ -8,7 +8,7 @@ qgisMinimumVersion=3.34.1
 qgisMaximumVersion=4.99
 supportsQt6=True
 description=This package includes the Snowflake Connector for QGIS.
-version=1.0.14
+version=1.0.15
 author=Snowflake Inc.
 email=erick.cuberojimenez@snowflake.com
 
@@ -21,10 +21,11 @@ repository=https://github.com/snowflakedb/qgis-snowflake-connector/
 # Recommended items:
 
 hasProcessingProvider=yes
-changelog=1.0.14 - Fix packaging: install under the valid Python package name
- qgis_snowflake_connector (underscore) instead of the hyphenated folder, which
- QGIS could not import consistently and caused a ModuleNotFoundError in
- SFFeatureSource when loading or rendering a layer.
+changelog=1.0.15 - Fix layer load/rendering error at its root: remove a stray
+ sys.path entry that let the plugin modules import under two names, causing a
+ ModuleNotFoundError in SFFeatureSource. Restores the canonical package folder
+ name for the QGIS plugin repository.
+ 1.0.14 - Packaging change (superseded by 1.0.15).
  1.0.13 - Fix SNOW-3712094 auth-config reuse: load the stored config
  with full=True so the connection alias is matched and the existing authcfg id
  is reused, instead of leaking a new QGIS auth config on every layer creation.

--- a/qgis_snowflake_connector.py
+++ b/qgis_snowflake_connector.py
@@ -46,8 +46,6 @@ __copyright__ = "(C) 2024 by Snowflake"
 __revision__ = "$Format:%H$"
 
 import os
-import sys
-import inspect
 import threading
 
 from qgis.core import (
@@ -65,11 +63,6 @@ from .sf_locator_filter import SFLocatorFilter
 from .sf_expression_functions import register_sf_functions, unregister_sf_functions
 
 from qgis.gui import QgsGui
-
-cmd_folder = os.path.split(inspect.getfile(inspect.currentframe()))[0]
-
-if cmd_folder not in sys.path:
-    sys.path.insert(0, cmd_folder)
 
 
 class QGISSnowflakeConnectorPlugin(object):

--- a/scripts/build_package.py
+++ b/scripts/build_package.py
@@ -17,7 +17,7 @@ import tempfile
 import zipfile
 from pathlib import Path
 
-PLUGIN_DIR_NAME = "qgis_snowflake_connector"
+PLUGIN_DIR_NAME = "qgis-snowflake-connector"
 
 EXCLUDE_ALWAYS = {
     ".git",


### PR DESCRIPTION
## Summary
- Remove the stray `sys.path.insert(0, cmd_folder)` in the plugin entry point that created a duplicate module tree and broke the deferred relative import in `SFFeatureSource` (`ModuleNotFoundError` on `featureSource()` / layer load under QGIS 3.44).
- Revert the packaging folder name back to the canonical hyphenated `qgis-snowflake-connector` required by plugins.qgis.org (the underscore folder from 1.0.14 was rejected on upload with a folder-name-mismatch).
- Bump to 1.0.15 with changelog.

## Verification
- Built `qgis-snowflake-connector-1.0.15.zip`: single top-level `qgis-snowflake-connector/` folder, `metadata.txt` + `__init__.py` present, `test/` excluded, `sys.path.insert` gone.
- Installed the hyphen build in QGIS 3.44.8 and confirmed via MCP: plugin loads/starts under the hyphen name, all modules load under one consistent tree (no duplicate top-level trees), the exact original failure (`SFFeatureSource.__init__` -> `from .sf_vector_data_provider import SFVectorDataProvider`) now succeeds, and URI redaction still returns the safe `authcfg=` form.

Made with [Cursor](https://cursor.com)