### PR TITLE
Bump to 1.0.16: packaging/metadata cleanup

### DIFF
--- a/metadata.txt
+++ b/metadata.txt
@@ -6,9 +6,8 @@
 name=Snowflake Connector for QGIS
 qgisMinimumVersion=3.34.1
 qgisMaximumVersion=4.99
-supportsQt6=True
 description=This package includes the Snowflake Connector for QGIS.
-version=1.0.15
+version=1.0.16
 author=Snowflake Inc.
 email=erick.cuberojimenez@snowflake.com
 
@@ -21,7 +20,11 @@ repository=https://github.com/snowflakedb/qgis-snowflake-connector/
 # Recommended items:
 
 hasProcessingProvider=yes
-changelog=1.0.15 - Fix layer load/rendering error at its root: remove a stray
+changelog=1.0.16 - Packaging/metadata cleanup for the QGIS plugin repository:
+ remove the deprecated supportsQt6 flag (QGIS 4 compatibility is set via
+ qgisMaximumVersion) and exclude the Sphinx help/make.bat from the package so
+ it no longer trips the repository's suspicious-file scan.
+ 1.0.15 - Fix layer load/rendering error at its root: remove a stray
  sys.path entry that let the plugin modules import under two names, causing a
  ModuleNotFoundError in SFFeatureSource. Restores the canonical package folder
  name for the QGIS plugin repository.

--- a/scripts/build_package.py
+++ b/scripts/build_package.py
@@ -101,7 +101,7 @@ def build_package(repo_root, output_dir, include_tests=False, slim=False):
                     item,
                     dest,
                     ignore=shutil.ignore_patterns(
-                        "__pycache__", "*.pyc", "*.pyo", ".DS_Store"
+                        "__pycache__", "*.pyc", "*.pyo", ".DS_Store", "*.bat"
                     ),
                 )
             else:


### PR DESCRIPTION
## Summary
- Remove the deprecated `supportsQt6` metadata flag (QGIS 4 compatibility is set via `qgisMaximumVersion=4.99`), clearing the upload deprecation warning.
- Exclude `.bat` files from the packaged plugin so the Sphinx `help/make.bat` no longer trips the plugins.qgis.org "Suspicious Files" scan.
- Bump version to 1.0.16 with changelog.

## Notes
Packaging/metadata only; no runtime behavior change.

Made with [Cursor](https://cursor.com)