### PR TITLE
Release v1.0.19: processing freeze fixes, import fix, safeguards

### DIFF
--- a/entities/sf_dynamic_connection_combo_box_widget.py
+++ b/entities/sf_dynamic_connection_combo_box_widget.py
@@ -159,6 +159,7 @@ class DynamicConnectionComboBoxWidget(WidgetWrapper):
                 _geo_column_type,
                 _primary_key,
                 _load_all_rows,
+                _single_geom_layer,
             ) = parse_uri(provider.dataSourceUri())
         except Exception:
             return

--- a/helpers/mappings.py
+++ b/helpers/mappings.py
@@ -23,6 +23,22 @@ def create_qgs_field(name, metatype, type_name="", sub_type=None):
     return field
 
 
+def map_numeric_type(data_type: str, numeric_scale):
+    """Map a Snowflake numeric column to a QMetaType, honoring scale.
+
+    A ``NUMBER``/``DECIMAL``/``NUMERIC`` column declared with scale 0 is an
+    integer (including primary keys); mapping it to ``Double`` makes QGIS show
+    values like ``1.0`` and breaks integer joins. Anything with a fractional
+    scale (or an unknown scale) falls back to the type table.
+    """
+    if data_type in ("NUMBER", "DECIMAL", "NUMERIC") and str(numeric_scale) in (
+        "0",
+        "0.0",
+    ):
+        return QMetaType.Type.LongLong
+    return mapping_snowflake_qgis_type[data_type]
+
+
 mapping_single_to_multi_geometry_type = {
     "Point": "MultiPoint",
     "LineString": "MultiLineString",

--- a/helpers/utils.py
+++ b/helpers/utils.py
@@ -392,6 +392,7 @@ def decodeUri(uri: str) -> Dict[str, str]:
         "geo_column_type",
         "primary_key",
         "load_all_rows",
+        "single_geom_layer",
     ]
     matches = re.findall(
         f"({'|'.join(supported_keys)})=(.*?) *?(?={'|'.join(supported_keys)}=|$)",

--- a/helpers/wrapper.py
+++ b/helpers/wrapper.py
@@ -20,6 +20,7 @@ def parse_uri(
     geo_column_type = parsed_uri.get("geo_column_type", None)
     primary_key = parsed_uri.get("primary_key", "")
     load_all_rows = parsed_uri.get("load_all_rows", "") == "1"
+    single_geom_layer = parsed_uri.get("single_geom_layer", "") == "1"
 
     # check parsing results
     if not connection_name:
@@ -41,4 +42,5 @@ def parse_uri(
         geo_column_type,
         primary_key,
         load_all_rows,
+        single_geom_layer,
     )

--- a/managers/sf_connection_manager.py
+++ b/managers/sf_connection_manager.py
@@ -13,6 +13,13 @@ from ..helpers.sql import quote_identifier
 
 _BASE_QUERY_TAG = "qgis-snowflake-connector"
 
+# Upper bound (seconds) for any single statement on a plugin connection. Acts
+# as a safety net so a pathological/stuck query (e.g. a bad server-side spatial
+# expression) can never block the QGIS main thread indefinitely; it aborts with
+# a recoverable error instead of freezing the UI. Generous enough not to affect
+# normal loads/exports.
+_STATEMENT_TIMEOUT_SECONDS = 900
+
 
 def build_op_tag(
     op: str,
@@ -105,6 +112,7 @@ class SFConnectionManager:
                 "client_session_keep_alive": True,
                 "session_parameters": {
                     "QUERY_TAG": _BASE_QUERY_TAG,
+                    "STATEMENT_TIMEOUT_IN_SECONDS": _STATEMENT_TIMEOUT_SECONDS,
                 },
             }
 

--- a/metadata.txt
+++ b/metadata.txt
@@ -7,7 +7,7 @@ name=Snowflake Connector for QGIS
 qgisMinimumVersion=3.34.1
 qgisMaximumVersion=4.99
 description=This package includes the Snowflake Connector for QGIS.
-version=1.0.16
+version=1.0.19
 author=Snowflake Inc.
 email=erick.cuberojimenez@snowflake.com
 
@@ -20,7 +20,27 @@ repository=https://github.com/snowflakedb/qgis-snowflake-connector/
 # Recommended items:
 
 hasProcessingProvider=yes
-changelog=1.0.16 - Packaging/metadata cleanup for the QGIS plugin repository:
+changelog=1.0.19 - Fixes from end-to-end processing testing:
+ * Buffer (server-side) on GEOGRAPHY no longer freezes QGIS. Snowflake's
+   optimizer produced a never-returning plan when ST_TRANSFORM and ST_BUFFER
+   were fused in one expression; the reproject/buffer/reproject steps are now
+   materialized into separate temporary tables.
+ * Import from Snowflake now stores numeric (NUMBER) values correctly instead
+   of silently dropping every feature (Decimal values are coerced to float).
+ * Connections set a bounded STATEMENT_TIMEOUT_IN_SECONDS so a stuck query can
+   no longer block the UI indefinitely.
+ 1.0.18 - Processing algorithms (Buffer, H3 index, Spatial join,
+ Execute SQL) now reuse the existing Snowflake connection instead of
+ force-closing and rebuilding it, fixing a UI freeze and the disruption of
+ already-loaded layers when running an algorithm.
+ 1.0.17 - Correctness and performance fixes from end-to-end testing:
+ integer/NUMBER columns (including primary keys) now display as integers instead
+ of decimals; table layers reference their fully-qualified database.schema.table
+ so counts/extent/queries no longer depend on the session's current schema;
+ single-geometry layers use a cheaper feature count; field type names now show
+ the Snowflake source type; and custom SQL-query layers no longer log a
+ misleading "primary key not verified" read-only reason.
+ 1.0.16 - Packaging/metadata cleanup for the QGIS plugin repository:
  remove the deprecated supportsQt6 flag (QGIS 4 compatibility is set via
  qgisMaximumVersion) and exclude the Sphinx help/make.bat from the package so
  it no longer trips the repository's suspicious-file scan.

--- a/processing/buffer_table.py
+++ b/processing/buffer_table.py
@@ -102,7 +102,11 @@ class BufferTableAlgorithm(QgsProcessingAlgorithm):
 
         auth = get_auth_information(connection_name)
         mgr = SFConnectionManager.get_instance()
-        mgr.connect(connection_name, auth)
+        # Reuse an existing open connection; connect() force-closes and rebuilds
+        # the shared session, which disrupts already-loaded layers and can freeze
+        # the UI thread when run synchronously.
+        if mgr.get_connection(connection_name) is None:
+            mgr.connect(connection_name, auth)
 
         qs = quote_identifier(schema)
         qt = quote_identifier(table)
@@ -141,27 +145,47 @@ class BufferTableAlgorithm(QgsProcessingAlgorithm):
             type_cursor.close()
         col_type = type_row[0] if type_row else "GEOGRAPHY"
 
-        if col_type == "GEOGRAPHY":
-            buffer_expr = (
-                f"TO_GEOGRAPHY(ST_TRANSFORM(ST_BUFFER("
-                f"ST_TRANSFORM(ST_SETSRID(TO_GEOMETRY({qg}), 4326), 3857)"
-                f", {distance}), 4326))"
-            )
-        else:
-            buffer_expr = f"ST_BUFFER({qg}, {distance})"
-
         create_verb = "CREATE OR REPLACE TABLE" if overwrite else "CREATE TABLE"
-        sql = (
-            f"{create_verb} {qs}.{qo} AS "  # nosec B608 - create_verb is a constant; identifiers escaped via quote_identifier; buffer_expr uses quoted identifiers and numeric distance
-            f"SELECT * EXCLUDE ({qg}), "
-            f"{buffer_expr} AS {qg} "
-            f"FROM {qs}.{qt}"
-        )
 
-        feedback.pushInfo(f"Running buffer ({col_type}): {sql}")
+        temp_tables = []
+        if col_type == "GEOGRAPHY":
+            # Snowflake has no native GEOGRAPHY buffer, so we reproject to a
+            # metric CRS (EPSG:3857), buffer there, then reproject back.
+            # CRITICAL: ST_TRANSFORM and ST_BUFFER must not be combined in a
+            # single expression -- the Snowflake optimizer then produces a
+            # pathological plan that effectively never returns (freezing the
+            # UI). We force a materialization boundary between each geometry
+            # operation via temporary tables so no statement fuses a transform
+            # with a buffer.
+            qtmp1 = quote_identifier(f"{output}__QGIS_BUF_S1")
+            qtmp2 = quote_identifier(f"{output}__QGIS_BUF_S2")
+            temp_tables = [qtmp1, qtmp2]
+            steps = [
+                f"CREATE OR REPLACE TEMPORARY TABLE {qs}.{qtmp1} AS "  # nosec B608 - identifiers escaped via quote_identifier
+                f"SELECT * EXCLUDE ({qg}), "
+                f"ST_TRANSFORM(ST_SETSRID(TO_GEOMETRY({qg}), 4326), 3857) AS {qg} "
+                f"FROM {qs}.{qt}",
+                f"CREATE OR REPLACE TEMPORARY TABLE {qs}.{qtmp2} AS "  # nosec B608 - identifiers escaped via quote_identifier; distance is numeric
+                f"SELECT * EXCLUDE ({qg}), "
+                f"ST_BUFFER({qg}, {distance}) AS {qg} "
+                f"FROM {qs}.{qtmp1}",
+                f"{create_verb} {qs}.{qo} AS "  # nosec B608 - create_verb is a constant; identifiers escaped via quote_identifier
+                f"SELECT * EXCLUDE ({qg}), "
+                f"TO_GEOGRAPHY(ST_TRANSFORM(ST_SETSRID({qg}, 3857), 4326)) AS {qg} "
+                f"FROM {qs}.{qtmp2}",
+            ]
+        else:
+            steps = [
+                f"{create_verb} {qs}.{qo} AS "  # nosec B608 - create_verb is a constant; identifiers escaped via quote_identifier; distance is numeric
+                f"SELECT * EXCLUDE ({qg}), "
+                f"ST_BUFFER({qg}, {distance}) AS {qg} "
+                f"FROM {qs}.{qt}"
+            ]
 
         try:
-            mgr.execute_query(connection_name, sql, ctx)
+            for step_sql in steps:
+                feedback.pushInfo(f"Running buffer ({col_type}): {step_sql}")
+                mgr.execute_query(connection_name, step_sql, ctx)
             count_cursor = mgr.execute_query(
                 connection_name,
                 f"SELECT COUNT(*) FROM {qs}.{qo}",  # nosec B608 - identifiers escaped via quote_identifier
@@ -176,5 +200,15 @@ class BufferTableAlgorithm(QgsProcessingAlgorithm):
         except Exception as e:
             summary = f"Error: {e}"
             feedback.reportError(summary)
+        finally:
+            for qtmp in temp_tables:
+                try:
+                    mgr.execute_query(
+                        connection_name,
+                        f"DROP TABLE IF EXISTS {qs}.{qtmp}",  # nosec B608 - identifiers escaped via quote_identifier
+                        ctx,
+                    )
+                except Exception:
+                    pass
 
         return {self.OUTPUT: summary}

--- a/processing/execute_sql.py
+++ b/processing/execute_sql.py
@@ -116,7 +116,11 @@ class ExecuteSQLAlgorithm(QgsProcessingAlgorithm):
 
         auth = get_auth_information(connection_name)
         mgr = SFConnectionManager.get_instance()
-        mgr.connect(connection_name, auth)
+        # Reuse an existing open connection; connect() force-closes and rebuilds
+        # the shared session, which disrupts already-loaded layers and can freeze
+        # the UI thread when run synchronously.
+        if mgr.get_connection(connection_name) is None:
+            mgr.connect(connection_name, auth)
 
         feedback.pushInfo(f"Executing SQL on '{connection_name}'...")
         try:

--- a/processing/h3_index.py
+++ b/processing/h3_index.py
@@ -100,7 +100,11 @@ class H3IndexAlgorithm(QgsProcessingAlgorithm):
 
         auth = get_auth_information(connection_name)
         mgr = SFConnectionManager.get_instance()
-        mgr.connect(connection_name, auth)
+        # Reuse an existing open connection; connect() force-closes and rebuilds
+        # the shared session, which disrupts already-loaded layers and can freeze
+        # the UI thread when run synchronously.
+        if mgr.get_connection(connection_name) is None:
+            mgr.connect(connection_name, auth)
 
         qs = quote_identifier(schema)
         qt = quote_identifier(table)

--- a/processing/import_from_snowflake.py
+++ b/processing/import_from_snowflake.py
@@ -1,6 +1,7 @@
 """Import from Snowflake -- download a Snowflake table to a local vector layer."""
 
 import os
+from decimal import Decimal
 
 from qgis.core import (
     QgsProcessingAlgorithm,
@@ -247,6 +248,11 @@ class ImportFromSnowflakeAlgorithm(QgsProcessingAlgorithm):
 
             feat = QgsFeature(fields)
             for j, val in enumerate(row[:-1]):
+                # Snowflake NUMBER columns come back as Decimal, which the
+                # memory/OGR providers cannot store into a double field
+                # (the feature is silently rejected). Coerce to float.
+                if isinstance(val, Decimal):
+                    val = float(val)
                 feat.setAttribute(j, val)
 
             wkb = row[-1]

--- a/processing/spatial_join.py
+++ b/processing/spatial_join.py
@@ -133,7 +133,11 @@ class SpatialJoinAlgorithm(QgsProcessingAlgorithm):
 
         auth = get_auth_information(connection_name)
         mgr = SFConnectionManager.get_instance()
-        mgr.connect(connection_name, auth)
+        # Reuse an existing open connection; connect() force-closes and rebuilds
+        # the shared session, which disrupts already-loaded layers and can freeze
+        # the UI thread when run synchronously.
+        if mgr.get_connection(connection_name) is None:
+            mgr.connect(connection_name, auth)
 
         qs = quote_identifier(schema)
         ql = quote_identifier(left)

--- a/providers/sf_feature_iterator.py
+++ b/providers/sf_feature_iterator.py
@@ -52,6 +52,11 @@ class SFFeatureIterator(QgsAbstractFeatureIterator):
         # self._expression even when the provider's features are already cached
         # (the block below that would otherwise set it is skipped). See issue #119.
         self._expression = ""
+        # Only a full, unfiltered load may populate the provider-shared cache
+        # and mark the layer loaded. A per-request filter (spatial rect, fid,
+        # pushed-down expression) must stream one-shot, otherwise the first
+        # filtered render would permanently cap the layer to that subset.
+        self._should_cache_features = False
 
         self._request = request if request is not None else QgsFeatureRequest()
         self._transform = QgsCoordinateTransform()
@@ -234,6 +239,19 @@ class SFFeatureIterator(QgsAbstractFeatureIterator):
                 if filter_geom_clause != "":
                     filter_geom_clause = f"and {filter_geom_clause}"
 
+            # A query is only safe to cache into the provider-shared feature
+            # list when it carried no per-request row filter. Otherwise a
+            # filtered render/identify would poison the cache and cap every
+            # later full-extent request to that subset. subsetString() is a
+            # stable provider-level filter (reloadData() clears the cache when
+            # it changes), so it is intentionally not part of this check.
+            self._should_cache_features = (
+                not getattr(self._provider, "_load_all_rows", False)
+                and feature_id_list is None
+                and self._expression == ""
+                and filter_geom_clause == ""
+            )
+
             # build the complete where clause
             where_clause = ""
             if where_clause_list:
@@ -369,7 +387,7 @@ class SFFeatureIterator(QgsAbstractFeatureIterator):
 
                 if not next_result or not self._provider.isValid():
                     f.setValid(False)
-                    if not getattr(self._provider, "_load_all_rows", False):
+                    if self._should_cache_features:
                         self._provider._features_loaded = True
                     return False
 
@@ -381,6 +399,10 @@ class SFFeatureIterator(QgsAbstractFeatureIterator):
                     f.setGeometry(geometry)
                     self.geometryToDestinationCrs(f, self._transform)
 
+                # Feature ids are the 0-based iteration order of this result
+                # set, NOT the table primary key. QGIS selection/editing use
+                # these fids to index the provider's cached feature list; edits
+                # then map fid -> cached feature -> primary key for the DML.
                 f.setId(self._index)
 
                 col_index_by_name = self._col_index_by_name
@@ -449,7 +471,7 @@ class SFFeatureIterator(QgsAbstractFeatureIterator):
                                 continue
                             f.setAttribute(indx, next_result[col_idx])
                 f.setValid(True)
-                if not getattr(self._provider, "_load_all_rows", False):
+                if self._should_cache_features:
                     self._provider._features.append(QgsFeature(f))
 
             self._index += 1

--- a/providers/sf_vector_data_provider.py
+++ b/providers/sf_vector_data_provider.py
@@ -45,13 +45,14 @@ from ..helpers.utils import (
 from ..managers.sf_connection_manager import SFConnectionManager, build_op_tag
 
 from ..helpers.wrapper import parse_uri
-from ..helpers.sql import quote_identifier, quote_literal
+from ..helpers.sql import quote_identifier, quote_literal, qualified_table_name
 from ..helpers.expression_compiler import compile_expression_to_sql
 from ..helpers.mappings import (
     SNOWFLAKE_METADATA_TYPE_CODE_DICT,
     create_qgs_field,
+    map_numeric_type,
+    mapping_multi_single_to_geometry_type,
     mapping_snowflake_qgis_geometry,
-    mapping_snowflake_qgis_type,
 )
 
 
@@ -91,6 +92,7 @@ class SFVectorDataProvider(QgsVectorDataProvider):
                 self._geo_column_type,
                 self._primary_key,
                 self._load_all_rows,
+                self._single_geom_layer,
             ) = parse_uri(uri)
 
         except Exception as e:
@@ -140,7 +142,18 @@ class SFVectorDataProvider(QgsVectorDataProvider):
                     limit_size=limit_size,
                 )
         else:
-            self._from_clause = quote_identifier(self._table_name)
+            # SNOW-3712xxx: fully-qualify the table so COUNT/extent/iteration
+            # target the layer's own database.schema.table instead of relying on
+            # the session's current schema (a shared connection can be pointed
+            # at another schema by a concurrent layer between USE SCHEMA and the
+            # SELECT). Fall back to the bare quoted name when db/schema unknown.
+            database_name = self._context_information.get("database_name")
+            if database_name and self._schema_name:
+                self._from_clause = qualified_table_name(
+                    database_name, self._schema_name, self._table_name
+                )
+            else:
+                self._from_clause = quote_identifier(self._table_name)
             if self._load_all_rows:
                 self._is_limited_unordered = False
             else:
@@ -255,10 +268,17 @@ class SFVectorDataProvider(QgsVectorDataProvider):
             if self._is_limited_unordered:
                 reasons.append("row-capped/unordered result (unstable feature ids)")
             # SNOW-3712083: refuse edits when the declared primary key cannot be
-            # confirmed unique.
+            # confirmed unique. Skip this reason for custom SQL query layers
+            # (there is no base table to validate against, so it would only add
+            # a misleading "primary key is not verified unique" to a layer whose
+            # real blocker is already "custom SQL query layer").
+            is_sql_query_layer = (
+                self._sql_query is not None and self._sql_query != ""
+            )
             if (
                 self._primary_key != ""
                 and not self._is_limited_unordered
+                and not is_sql_query_layer
                 and not self._validate_primary_key()
             ):
                 reasons.append("primary key is not verified unique")
@@ -361,7 +381,7 @@ class SFVectorDataProvider(QgsVectorDataProvider):
                             f" {quote_literal(database_name)}"
                         )
                     query = (
-                        "SELECT DISTINCT column_name, data_type, ordinal_position"  # nosec B608 - values escaped via quote_literal; catalog_filter/schema_filter built with quote_literal above
+                        "SELECT DISTINCT column_name, data_type, numeric_scale, ordinal_position"  # nosec B608 - values escaped via quote_literal; catalog_filter/schema_filter built with quote_literal above
                         " FROM information_schema.columns "
                         f"WHERE table_name ILIKE {quote_literal(self._table_name)}"
                         f"{catalog_filter}"
@@ -379,9 +399,11 @@ class SFVectorDataProvider(QgsVectorDataProvider):
                     field_info = cur.fetchall()
                     cur.close()
                     for row in field_info:
-                        field_name, field_type = row[0], row[1]
+                        field_name, field_type, numeric_scale = row[0], row[1], row[2]
                         qgs_field = create_qgs_field(
-                            field_name, mapping_snowflake_qgis_type[field_type]
+                            field_name,
+                            map_numeric_type(field_type, numeric_scale),
+                            type_name=field_type,
                         )
                         self._fields.append(qgs_field)
                 else:
@@ -397,12 +419,23 @@ class SFVectorDataProvider(QgsVectorDataProvider):
                     for data in description:
                         # it is already used to set the feature id
                         if data[1] not in [14, 15]:
+                            meta = SNOWFLAKE_METADATA_TYPE_CODE_DICT.get(
+                                data[1],
+                                SNOWFLAKE_METADATA_TYPE_CODE_DICT[2],
+                            )
+                            qvariant_type = meta.get("qvariant_type")
+                            # description scale is at index 5; a FIXED (NUMBER)
+                            # column with scale 0 is an integer, not a Double.
+                            scale = data[5] if len(data) > 5 else None
+                            if meta.get("name") == "FIXED" and str(scale) in (
+                                "0",
+                                "0.0",
+                            ):
+                                qvariant_type = QMetaType.Type.LongLong
                             qgs_field = create_qgs_field(
                                 data[0],
-                                SNOWFLAKE_METADATA_TYPE_CODE_DICT.get(
-                                    data[1],
-                                    SNOWFLAKE_METADATA_TYPE_CODE_DICT[2],
-                                ).get("qvariant_type"),
+                                qvariant_type,
+                                type_name=meta.get("name", ""),
                             )
                             self._fields.append(qgs_field)
 
@@ -620,6 +653,7 @@ class SFVectorDataProvider(QgsVectorDataProvider):
     _QGIS_TO_SF_TYPE = {
         QMetaType.Type.QString: "TEXT",
         QMetaType.Type.Int: "INTEGER",
+        QMetaType.Type.LongLong: "NUMBER",
         QMetaType.Type.Double: "DOUBLE",
         QMetaType.Type.QDate: "DATE",
         QMetaType.Type.QTime: "TIME",
@@ -627,11 +661,28 @@ class SFVectorDataProvider(QgsVectorDataProvider):
         QMetaType.Type.Bool: "BOOLEAN",
     }
 
+    def _ensure_features_loaded(self) -> None:
+        """Populate the fid-indexed feature cache if it is empty.
+
+        The edit methods map a QGIS feature id to its row via self._features,
+        which reloadData() clears after every commit. In the normal UI flow
+        QGIS re-reads features (repopulating the cache) before the next edit,
+        but consecutive programmatic edits can index an empty cache and crash.
+        A full getFeatures() pass rebuilds the cache with the same 0-based fids.
+        """
+        if not self._features:
+            for _ in self.getFeatures():
+                pass
+
     def changeGeometryValues(self, geometry_map: typing.Any) -> bool:
         if isinstance(geometry_map, dict) and geometry_map:
+            self._ensure_features_loaded()
             all_ok = True
             for f_key, geometry in geometry_map.items():
                 geometry: QgsGeometry
+                if f_key < 0 or f_key >= len(self._features):
+                    all_ok = False
+                    continue
                 feature: QgsFeature = self._features[f_key]
                 context = copy.deepcopy(self._context_information)
                 context["geometry_wkt"] = geometry.asWkt()
@@ -656,6 +707,7 @@ class SFVectorDataProvider(QgsVectorDataProvider):
         if not isinstance(attr_map, dict) or not attr_map:
             return False
         try:
+            self._ensure_features_loaded()
             all_ok = True
             fields = self.fields()
             pk_name = self.primary_key()
@@ -725,10 +777,19 @@ class SFVectorDataProvider(QgsVectorDataProvider):
         if not fids:
             return False
         try:
+            self._ensure_features_loaded()
             pk_values = []
             for fid in fids:
+                if fid < 0 or fid >= len(self._features):
+                    self.pushError(
+                        f"deleteFeatures: feature id {fid} is not in the current "
+                        "feature cache; skipping."
+                    )
+                    continue
                 feature: QgsFeature = self._features[fid]
                 pk_values.append(self._unwrap_value(feature.attribute(self.primary_key())))
+            if not pk_values:
+                return False
             context = copy.deepcopy(self._context_information)
             context["primary_key_name"] = self.primary_key()
             context["table_name"] = self._table_name
@@ -824,19 +885,51 @@ class SFGeoVectorDataProvider(SFVectorDataProvider):
     ):
         super().__init__(uri, providerOptions, flags)
 
+    def _geometry_type_filter(self) -> str:
+        """Return the geometry-type predicate the feature iterator uses so
+        COUNT/extent match the rows the layer actually shows.
+
+        A GEOGRAPHY/GEOMETRY column can mix geometry families; the plugin
+        splits those into one layer per type, so featureCount()/extent() must
+        restrict to this layer's type (plus its single/multi partner) instead
+        of counting the whole table.
+        """
+        qgeom = quote_identifier(self._column_geom)
+        types = [self._geometry_type]
+        mapped = mapping_multi_single_to_geometry_type.get(self._geometry_type)
+        if mapped:
+            types.append(mapped)
+        in_list = ", ".join(quote_literal(t) for t in types)
+        return f"ST_ASGEOJSON({qgeom}):type::string IN ({in_list})"  # nosec B608 - identifier escaped via quote_identifier; types escaped via quote_literal
+
     def featureCount(self) -> int:
         """returns the number of entities in the table"""
 
-        if not self._feature_count:
+        if self._feature_count is None:
             if not self._is_valid:
                 self._feature_count = 0
             else:
                 if self._is_limited_unordered:
                     self._feature_count = limit_size_for_type(self._geo_column_type)
                 else:
-                    query = f"SELECT COUNT(*) FROM {self._from_clause}"  # nosec B608 - from_clause pre-quoted
+                    # The feature iterator always restricts rows to this layer's
+                    # geometry type (which also drops NULL geometries), so COUNT
+                    # must match. For a single-geometry-family layer every
+                    # non-null row is that one type, so a cheap "geom IS NOT
+                    # NULL" is an exact equivalent that avoids the per-row
+                    # ST_ASGEOJSON parse the type predicate would cost.
+                    where_parts = []
+                    if getattr(self, "_single_geom_layer", False):
+                        where_parts.append(
+                            f"{quote_identifier(self._column_geom)} IS NOT NULL"  # nosec B608 - identifier escaped via quote_identifier
+                        )
+                    else:
+                        where_parts.append(self._geometry_type_filter())
                     if self.subsetString():
-                        query += f" WHERE {self.subsetString()}"  # nosec B608 - subsetString is compiler-validated & quoted in setSubsetString
+                        where_parts.append(self.subsetString())  # nosec B608 - subsetString is compiler-validated & quoted in setSubsetString
+                    query = f"SELECT COUNT(*) FROM {self._from_clause}"  # nosec B608 - from_clause pre-quoted; geometry-type filter escaped in _geometry_type_filter
+                    if where_parts:
+                        query += " WHERE " + " AND ".join(where_parts)
 
                     cur = self.connection_manager.execute_query(
                         connection_name=self._connection_name,
@@ -862,14 +955,16 @@ class SFGeoVectorDataProvider(SFVectorDataProvider):
                 self._extent = QgsRectangle()
             else:
                 qgeom = quote_identifier(self._column_geom)
+                where_clause = f"{qgeom} IS NOT NULL"
+                if not getattr(self, "_single_geom_layer", False):
+                    where_clause += f" AND {self._geometry_type_filter()}"
                 query = (
-                    f'SELECT MIN(ST_XMIN({qgeom})), '  # nosec B608 - identifier escaped via quote_identifier; from_clause pre-quoted; geometry_type escaped via quote_literal
+                    f'SELECT MIN(ST_XMIN({qgeom})), '  # nosec B608 - identifier escaped via quote_identifier; from_clause pre-quoted; geometry-type filter escaped in _geometry_type_filter
                     f'MIN(ST_YMIN({qgeom})), '
                     f'MAX(ST_XMAX({qgeom})), '
                     f'MAX(ST_YMAX({qgeom})) '
                     f"FROM {self._from_clause} "
-                    f'WHERE {qgeom} IS NOT NULL AND '
-                    f"ST_ASGEOJSON({qgeom}):type ILIKE {quote_literal(self._geometry_type)}"
+                    f"WHERE {where_clause}"
                 )
 
                 cur = self.connection_manager.execute_query(
@@ -915,7 +1010,7 @@ class SFH3VectorDataProvider(SFVectorDataProvider):
 
     def featureCount(self) -> int:
         """returns the number of entities in the table"""
-        if not self._feature_count:
+        if self._feature_count is None:
             if not self._is_valid:
                 self._feature_count = 0
             else:

--- a/qgis_snowflake_connector_algorithm.py
+++ b/qgis_snowflake_connector_algorithm.py
@@ -538,6 +538,7 @@ class QGISSnowflakeConnectorAlgorithm(QgsProcessingAlgorithm):
                 _geo_column_type,
                 _primary_key,
                 _load_all_rows,
+                _single_geom_layer,
             ) = parse_uri(provider.dataSourceUri())
         except Exception:
             return False

--- a/tasks/sf_convert_column_to_layer_task.py
+++ b/tasks/sf_convert_column_to_layer_task.py
@@ -102,6 +102,11 @@ class SFConvertColumnToLayerTask(QgsTask):
                 )
                 if self.load_all_rows:
                     uri += " load_all_rows=1"
+                # When the column has a single geometry family the layer covers
+                # every row, so featureCount()/extent() can skip the per-row
+                # geometry-type predicate and use a fast metadata COUNT(*).
+                if len(geo_type_list) == 1:
+                    uri += " single_geom_layer=1"
 
                 layer_name = (
                     self.table

--- a/tasks/sf_convert_sql_query_to_layer_task.py
+++ b/tasks/sf_convert_sql_query_to_layer_task.py
@@ -97,6 +97,10 @@ class SFConvertSQLQueryToLayerTask(QgsTask):
                     f"geo_column_type={geo_column_type} "
                     f"primary_key={self.primary_key}"
                 )
+                # Single geometry family -> the layer covers every row, so
+                # featureCount()/extent() can skip the per-row type predicate.
+                if len(geo_type_list) == 1:
+                    uri += " single_geom_layer=1"
 
                 layer_name = (
                     self.layer_name

--- a/test/test_issue_regressions.py
+++ b/test/test_issue_regressions.py
@@ -732,11 +732,17 @@ class TestPhase2SQLInjectionCallSites(unittest.TestCase):
 
     def test_geometry_type_escaped_in_extent_query(self):
         """SNOW-3712085: _geometry_type comes from the (project-file) URI and
-        must be escaped as a literal, not interpolated inside raw quotes."""
+        must be escaped as a literal, not interpolated inside raw quotes. The
+        escaping now lives in the shared _geometry_type_filter() helper, which
+        both featureCount() and extent() delegate to."""
         content = (ROOT / "providers" / "sf_vector_data_provider.py").read_text(
             encoding="utf-8"
         )
-        self.assertIn("quote_literal(self._geometry_type)", content)
+        idx = content.index("def _geometry_type_filter(self)")
+        next_def = content.index("\n    def ", idx + 1)
+        helper_body = content[idx:next_def]
+        self.assertIn("self._geometry_type", helper_body)
+        self.assertIn("quote_literal(", helper_body)
         self.assertNotIn("ILIKE '{self._geometry_type}'", content)
 
     def test_geometry_type_escaped_in_feature_iterator(self):
@@ -2029,6 +2035,326 @@ class TestQualityBaseline(unittest.TestCase):
         self.assertIn("class TestProviderLifecycle", content)
         self.assertIn("class TestUIBoundary", content)
         self.assertIn("class TestQualityBaseline", content)
+
+
+class TestFeatureCachePoisoning(unittest.TestCase):
+    """Regression: a per-request-filtered query (spatial rect, fid, or pushed-
+    down expression) must NOT populate the provider-shared feature cache or
+    mark the layer fully loaded. Otherwise the first filtered render caps the
+    layer to that subset for every later full-extent request.
+    """
+
+    def _iterator_content(self):
+        return (ROOT / "providers" / "sf_feature_iterator.py").read_text(
+            encoding="utf-8"
+        )
+
+    def test_should_cache_features_flag_defined(self):
+        content = self._iterator_content()
+        self.assertIn("self._should_cache_features", content)
+        self.assertIn("self._should_cache_features = (", content)
+
+    def test_cache_gate_condition(self):
+        """The gate must fail closed for any per-request filter."""
+        content = self._iterator_content()
+        idx = content.index("self._should_cache_features = (")
+        block = content[idx:idx + 300]
+        self.assertIn(
+            'not getattr(self._provider, "_load_all_rows", False)', block
+        )
+        self.assertIn("and feature_id_list is None", block)
+        self.assertIn('and self._expression == ""', block)
+        self.assertIn('and filter_geom_clause == ""', block)
+
+    def test_features_loaded_gated_on_flag(self):
+        content = self._iterator_content()
+        self.assertIn(
+            "if self._should_cache_features:\n"
+            "                        self._provider._features_loaded = True",
+            content,
+        )
+        # The old load_all_rows-only guard must no longer wrap this write.
+        self.assertNotIn(
+            'if not getattr(self._provider, "_load_all_rows", False):\n'
+            "                        self._provider._features_loaded = True",
+            content,
+        )
+
+    def test_features_append_gated_on_flag(self):
+        content = self._iterator_content()
+        self.assertIn(
+            "if self._should_cache_features:\n"
+            "                    self._provider._features.append(QgsFeature(f))",
+            content,
+        )
+        self.assertNotIn(
+            'if not getattr(self._provider, "_load_all_rows", False):\n'
+            "                    self._provider._features.append(QgsFeature(f))",
+            content,
+        )
+
+
+class TestGeometryTypeCountFilter(unittest.TestCase):
+    """Regression: featureCount() and extent() must restrict to the layer's
+    geometry type (plus its single/multi partner) so a geometry column that
+    mixes families does not over-count or compute the wrong extent.
+    """
+
+    def _provider_content(self):
+        return (ROOT / "providers" / "sf_vector_data_provider.py").read_text(
+            encoding="utf-8"
+        )
+
+    def test_geometry_type_filter_helper_exists(self):
+        content = self._provider_content()
+        self.assertIn("def _geometry_type_filter(self)", content)
+        idx = content.index("def _geometry_type_filter(self)")
+        next_def = content.index("\n    def ", idx + 1)
+        body = content[idx:next_def]
+        self.assertIn("mapping_multi_single_to_geometry_type", body)
+        self.assertIn("quote_identifier(self._column_geom)", body)
+        self.assertIn("quote_literal(", body)
+        self.assertIn("ST_ASGEOJSON(", body)
+        self.assertIn("IN (", body)
+
+    def test_helper_imported(self):
+        content = self._provider_content()
+        self.assertIn("mapping_multi_single_to_geometry_type", content)
+
+    def test_feature_count_uses_geometry_type_filter(self):
+        content = self._provider_content()
+        # SFGeoVectorDataProvider.featureCount applies the geometry-type filter
+        # (unless the single-geom fast path is active) and builds COUNT(*).
+        self.assertIn("SELECT COUNT(*) FROM {self._from_clause}", content)
+        self.assertIn("where_parts.append(self._geometry_type_filter())", content)
+
+    def test_extent_uses_geometry_type_filter_not_ilike(self):
+        content = self._provider_content()
+        self.assertIn("{self._geometry_type_filter()}", content)
+        # The old single-type ILIKE form must be gone.
+        self.assertNotIn(":type ILIKE ", content)
+
+
+class TestIntegerColumnMapping(unittest.TestCase):
+    """Regression: NUMBER/DECIMAL columns with scale 0 (including primary keys)
+    must map to an integer QMetaType, not Double (which renders 1.0)."""
+
+    def _mappings(self):
+        return (ROOT / "helpers" / "mappings.py").read_text(encoding="utf-8")
+
+    def _provider(self):
+        return (ROOT / "providers" / "sf_vector_data_provider.py").read_text(
+            encoding="utf-8"
+        )
+
+    def test_map_numeric_type_helper_exists(self):
+        content = self._mappings()
+        self.assertIn("def map_numeric_type(", content)
+        idx = content.index("def map_numeric_type(")
+        body = content[idx:idx + 900]
+        self.assertIn("QMetaType.Type.LongLong", body)
+        self.assertIn("NUMBER", body)
+        self.assertIn("DECIMAL", body)
+
+    def test_table_branch_uses_scale_and_helper(self):
+        content = self._provider()
+        self.assertIn("map_numeric_type", content)
+        # The information_schema query must fetch numeric_scale.
+        self.assertIn("numeric_scale", content)
+        self.assertIn("map_numeric_type(field_type, numeric_scale)", content)
+
+    def test_sql_query_branch_detects_fixed_scale_zero(self):
+        content = self._provider()
+        # description scale is index 5; FIXED with scale 0 -> LongLong.
+        self.assertIn("data[5]", content)
+        self.assertIn('meta.get("name") == "FIXED"', content)
+        self.assertIn("QMetaType.Type.LongLong", content)
+
+    def test_longlong_roundtrips_in_addAttributes_map(self):
+        content = self._provider()
+        self.assertIn('QMetaType.Type.LongLong: "NUMBER"', content)
+
+
+class TestSchemaQualifiedFromClause(unittest.TestCase):
+    """Regression: the table-branch from_clause must be fully qualified so
+    COUNT/extent/iteration do not depend on the session's current schema."""
+
+    def _provider(self):
+        return (ROOT / "providers" / "sf_vector_data_provider.py").read_text(
+            encoding="utf-8"
+        )
+
+    def test_imports_qualified_helper(self):
+        content = self._provider()
+        self.assertIn("qualified_table_name", content)
+
+    def test_table_branch_qualifies(self):
+        content = self._provider()
+        self.assertIn(
+            "qualified_table_name(\n"
+            "                    database_name, self._schema_name, self._table_name\n"
+            "                )",
+            content,
+        )
+        # Bare-name fallback is still present for the db/schema-unknown case.
+        self.assertIn(
+            "self._from_clause = quote_identifier(self._table_name)", content
+        )
+
+
+class TestSingleGeomCountFastPath(unittest.TestCase):
+    """Regression: a single-geometry-family layer must skip the per-row
+    ST_ASGEOJSON type predicate so featureCount() uses a metadata COUNT(*)."""
+
+    def _provider(self):
+        return (ROOT / "providers" / "sf_vector_data_provider.py").read_text(
+            encoding="utf-8"
+        )
+
+    def test_uri_key_supported(self):
+        utils = (ROOT / "helpers" / "utils.py").read_text(encoding="utf-8")
+        self.assertIn('"single_geom_layer"', utils)
+
+    def test_parse_uri_returns_flag(self):
+        wrapper = (ROOT / "helpers" / "wrapper.py").read_text(encoding="utf-8")
+        self.assertIn(
+            'single_geom_layer = parsed_uri.get("single_geom_layer", "") == "1"',
+            wrapper,
+        )
+        self.assertIn("single_geom_layer,", wrapper)
+
+    def test_featurecount_and_extent_branch_on_flag(self):
+        content = self._provider()
+        self.assertEqual(content.count('getattr(self, "_single_geom_layer", False)'), 2)
+
+    def test_tasks_set_flag_when_single_type(self):
+        col = (ROOT / "tasks" / "sf_convert_column_to_layer_task.py").read_text(
+            encoding="utf-8"
+        )
+        sql = (ROOT / "tasks" / "sf_convert_sql_query_to_layer_task.py").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("single_geom_layer=1", col)
+        self.assertIn("single_geom_layer=1", sql)
+
+
+class TestFeatureCountCacheSentinel(unittest.TestCase):
+    """Regression: an empty layer (count 0) must not re-run COUNT every call."""
+
+    def test_uses_is_none_sentinel(self):
+        content = (ROOT / "providers" / "sf_vector_data_provider.py").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("if self._feature_count is None:", content)
+        # The old truthiness check must be gone from the count getters.
+        self.assertNotIn("if not self._feature_count:", content)
+
+
+class TestEditCacheGuards(unittest.TestCase):
+    """Regression: edit methods must not IndexError when the fid-indexed
+    feature cache is empty (e.g. right after a commit's reloadData())."""
+
+    def _provider(self):
+        return (ROOT / "providers" / "sf_vector_data_provider.py").read_text(
+            encoding="utf-8"
+        )
+
+    def test_ensure_features_loaded_helper_exists(self):
+        content = self._provider()
+        self.assertIn("def _ensure_features_loaded(self)", content)
+
+    def test_edit_methods_call_ensure_and_guard(self):
+        content = self._provider()
+        # All three edit methods repopulate the cache before indexing it.
+        self.assertEqual(content.count("self._ensure_features_loaded()"), 3)
+        # changeGeometryValues bounds-checks the key it indexes.
+        self.assertIn("if f_key < 0 or f_key >= len(self._features):", content)
+        # deleteFeatures bounds-checks each fid too.
+        self.assertEqual(
+            content.count("if fid < 0 or fid >= len(self._features):"), 2
+        )
+
+
+class TestProcessingConnectionReuse(unittest.TestCase):
+    """Regression: processing algorithms must reuse an existing open connection.
+
+    SFConnectionManager.connect() force-closes and rebuilds the shared session,
+    which disrupts already-loaded layers and can freeze the UI thread. Every
+    algorithm must guard the call with `get_connection(...) is None`.
+    """
+
+    def test_no_unguarded_connect_in_processing(self):
+        processing_dir = ROOT / "processing"
+        offenders = []
+        for path in sorted(processing_dir.glob("*.py")):
+            lines = path.read_text(encoding="utf-8").splitlines()
+            for i, line in enumerate(lines):
+                stripped = line.strip()
+                if not stripped.startswith("mgr.connect("):
+                    continue
+                # The two preceding non-blank lines must contain the guard.
+                window = "\n".join(lines[max(0, i - 3):i])
+                if "get_connection(" not in window:
+                    offenders.append(f"{path.name}:{i + 1}")
+        self.assertEqual(
+            offenders,
+            [],
+            f"Unguarded mgr.connect() in processing algorithms: {offenders}",
+        )
+
+
+class TestBufferTransformNotFused(unittest.TestCase):
+    """Regression: the GEOGRAPHY buffer must not fuse ST_TRANSFORM with
+    ST_BUFFER in one SQL expression.
+
+    Snowflake's optimizer produces a pathological plan for
+    ST_TRANSFORM(ST_BUFFER(...)) / ST_BUFFER(ST_TRANSFORM(...)) that never
+    returns and freezes the QGIS UI. The algorithm must materialize each
+    geometry operation into a separate (temporary) table so no single
+    statement combines a transform with a buffer.
+    """
+
+    def _source(self):
+        return (ROOT / "processing" / "buffer_table.py").read_text(encoding="utf-8")
+
+    def test_no_transform_buffer_fusion(self):
+        src = self._source()
+        # Collapse whitespace so multi-line f-strings are matched too.
+        flat = re.sub(r"\s+", "", src)
+        self.assertNotIn("ST_TRANSFORM(ST_BUFFER", flat)
+        self.assertNotIn("ST_BUFFER(ST_TRANSFORM", flat)
+
+    def test_uses_temporary_materialization(self):
+        src = self._source()
+        self.assertIn("CREATE OR REPLACE TEMPORARY TABLE", src)
+
+
+class TestStatementTimeoutSafetyNet(unittest.TestCase):
+    """Regression: connections must set a bounded STATEMENT_TIMEOUT so a stuck
+    query can never block the QGIS main thread indefinitely.
+    """
+
+    def test_statement_timeout_in_session_parameters(self):
+        src = (
+            ROOT / "managers" / "sf_connection_manager.py"
+        ).read_text(encoding="utf-8")
+        self.assertIn("STATEMENT_TIMEOUT_IN_SECONDS", src)
+
+
+class TestImportDecimalCoercion(unittest.TestCase):
+    """Regression: imported Snowflake NUMBER values arrive as Decimal, which
+    the memory/OGR providers cannot store into a double field (the feature is
+    silently rejected). The import loop must coerce Decimal to float.
+    """
+
+    def test_decimal_coerced_to_float(self):
+        src = (
+            ROOT / "processing" / "import_from_snowflake.py"
+        ).read_text(encoding="utf-8")
+        self.assertIn("Decimal", src)
+        flat = re.sub(r"\s+", "", src)
+        self.assertIn("isinstance(val,Decimal)", flat)
+        self.assertIn("float(val)", flat)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- **Buffer (server-side) on GEOGRAPHY no longer freezes QGIS** — Snowflake's optimizer produced a never-returning plan when `ST_TRANSFORM` and `ST_BUFFER` were fused in one expression; the reproject/buffer/reproject steps are now materialized into separate temporary tables.
- **Import from Snowflake stores NUMBER values correctly** instead of silently dropping every feature (`Decimal` coerced to `float`).
- **Bounded `STATEMENT_TIMEOUT_IN_SECONDS`** so a stuck query can't block the UI indefinitely.
- Processing algorithms reuse the existing Snowflake connection instead of force-closing it.
- Feature-cache / geometry-type-filter correctness, single-geometry fast paths, edit-cache guards, scale-aware numeric mapping.

## Test plan
- [x] `python test/test_issue_regressions.py` — 168 tests pass
- [x] Live MCP end-to-end: data loading, editing, schema ops, Export, and all 6 processing algorithms — no freeze
- [ ] Reinstall `qgis-snowflake-connector-1.0.19.zip` and re-run from the Processing Toolbox GUI

Made with [Cursor](https://cursor.com)