### PR TITLE
Release 1.0.22: feature-edit crash fix (+ 1.0.20/1.0.21 fixes)

### DIFF
--- a/metadata.txt
+++ b/metadata.txt
@@ -7,7 +7,7 @@ name=Snowflake Connector for QGIS
 qgisMinimumVersion=3.34.1
 qgisMaximumVersion=4.99
 description=This package includes the Snowflake Connector for QGIS.
-version=1.0.19
+version=1.0.20
 author=Snowflake Inc.
 email=erick.cuberojimenez@snowflake.com
 
@@ -20,7 +20,13 @@ repository=https://github.com/snowflakedb/qgis-snowflake-connector/
 # Recommended items:
 
 hasProcessingProvider=yes
-changelog=1.0.19 - Fixes from end-to-end processing testing:
+changelog=1.0.20 - Fix from end-to-end processing testing: Import from
+ Snowflake now stores TIMESTAMP/DATE/TIME columns correctly instead of
+ silently dropping every feature. Snowflake returns temporal values as
+ Python datetime objects, which the memory/OGR sink cannot store directly;
+ they are now coerced to QDateTime/QDate/QTime, mirroring the existing
+ NUMBER (Decimal) handling.
+ 1.0.19 - Fixes from end-to-end processing testing:
  * Buffer (server-side) on GEOGRAPHY no longer freezes QGIS. Snowflake's
    optimizer produced a never-returning plan when ST_TRANSFORM and ST_BUFFER
    were fused in one expression; the reproject/buffer/reproject steps are now

--- a/metadata.txt
+++ b/metadata.txt
@@ -7,7 +7,7 @@ name=Snowflake Connector for QGIS
 qgisMinimumVersion=3.34.1
 qgisMaximumVersion=4.99
 description=This package includes the Snowflake Connector for QGIS.
-version=1.0.20
+version=1.0.21
 author=Snowflake Inc.
 email=erick.cuberojimenez@snowflake.com
 
@@ -20,7 +20,13 @@ repository=https://github.com/snowflakedb/qgis-snowflake-connector/
 # Recommended items:
 
 hasProcessingProvider=yes
-changelog=1.0.20 - Fix from end-to-end processing testing: Import from
+changelog=1.0.21 - Fix from end-to-end feature testing: the custom Snowflake
+ expression functions (sf_h3_resolution, sf_h3_is_valid, sf_h3_to_string) were
+ declared with an extra "node" parameter that QGIS never injects, so every call
+ raised a TypeError and returned NULL in the field calculator, labeling, and
+ symbology. The unused parameter was removed so the functions evaluate
+ correctly.
+ 1.0.20 - Fix from end-to-end processing testing: Import from
  Snowflake now stores TIMESTAMP/DATE/TIME columns correctly instead of
  silently dropping every feature. Snowflake returns temporal values as
  Python datetime objects, which the memory/OGR sink cannot store directly;

--- a/metadata.txt
+++ b/metadata.txt
@@ -7,7 +7,7 @@ name=Snowflake Connector for QGIS
 qgisMinimumVersion=3.34.1
 qgisMaximumVersion=4.99
 description=This package includes the Snowflake Connector for QGIS.
-version=1.0.21
+version=1.0.22
 author=Snowflake Inc.
 email=erick.cuberojimenez@snowflake.com
 
@@ -20,7 +20,13 @@ repository=https://github.com/snowflakedb/qgis-snowflake-connector/
 # Recommended items:
 
 hasProcessingProvider=yes
-changelog=1.0.21 - Fix from end-to-end feature testing: the custom Snowflake
+changelog=1.0.22 - Fix from end-to-end feature testing: editing a feature on a
+ Snowflake layer crashed with "TypeError: list indices must be integers or
+ slices, not str" because FilterFid/FilterFids requests were pushed down to SQL
+ using a column name as a list index. Feature ids are fetch-order positions, not
+ primary keys, so these requests are now resolved from the in-memory feature
+ cache instead, fixing the identify/attribute-table edit workflow.
+ 1.0.21 - Fix from end-to-end feature testing: the custom Snowflake
  expression functions (sf_h3_resolution, sf_h3_is_valid, sf_h3_to_string) were
  declared with an extra "node" parameter that QGIS never injects, so every call
  raised a TypeError and returned NULL in the field calculator, labeling, and

--- a/processing/import_from_snowflake.py
+++ b/processing/import_from_snowflake.py
@@ -1,5 +1,6 @@
 """Import from Snowflake -- download a Snowflake table to a local vector layer."""
 
+import datetime
 import os
 from decimal import Decimal
 
@@ -16,7 +17,7 @@ from qgis.core import (
     QgsWkbTypes,
     QgsCoordinateReferenceSystem,
 )
-from qgis.PyQt.QtCore import QCoreApplication, QMetaType
+from qgis.PyQt.QtCore import QCoreApplication, QDate, QDateTime, QMetaType, QTime
 from qgis.PyQt.QtGui import QIcon
 
 _IMAGES_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), "ui", "images")
@@ -248,11 +249,24 @@ class ImportFromSnowflakeAlgorithm(QgsProcessingAlgorithm):
 
             feat = QgsFeature(fields)
             for j, val in enumerate(row[:-1]):
-                # Snowflake NUMBER columns come back as Decimal, which the
-                # memory/OGR providers cannot store into a double field
-                # (the feature is silently rejected). Coerce to float.
+                # Snowflake NUMBER columns come back as Decimal, and TIMESTAMP/
+                # DATE/TIME columns come back as Python datetime objects. The
+                # memory/OGR providers cannot store either raw Python type into
+                # their target field (the whole feature is silently rejected),
+                # so coerce them to the matching Qt type first.
                 if isinstance(val, Decimal):
                     val = float(val)
+                elif isinstance(val, datetime.datetime):
+                    val = QDateTime(
+                        QDate(val.year, val.month, val.day),
+                        QTime(val.hour, val.minute, val.second,
+                              val.microsecond // 1000),
+                    )
+                elif isinstance(val, datetime.date):
+                    val = QDate(val.year, val.month, val.day)
+                elif isinstance(val, datetime.time):
+                    val = QTime(val.hour, val.minute, val.second,
+                                val.microsecond // 1000)
                 feat.setAttribute(j, val)
 
             wkb = row[-1]

--- a/providers/sf_feature_iterator.py
+++ b/providers/sf_feature_iterator.py
@@ -57,6 +57,9 @@ class SFFeatureIterator(QgsAbstractFeatureIterator):
         # pushed-down expression) must stream one-shot, otherwise the first
         # filtered render would permanently cap the layer to that subset.
         self._should_cache_features = False
+        # Initialized unconditionally: fetchFeature() reads self._target_fids
+        # even when __init__ returns early (invalid provider / CRS exception).
+        self._target_fids = None
 
         self._request = request if request is not None else QgsFeatureRequest()
         self._transform = QgsCoordinateTransform()
@@ -83,6 +86,24 @@ class SFFeatureIterator(QgsAbstractFeatureIterator):
         if getattr(self._provider, "_load_all_rows", False):
             self._provider._features_loaded = False
             self._provider._features = []
+
+        # FilterFid/FilterFids cannot be resolved in SQL: feature ids are the
+        # 0-based fetch order of the result set (f.setId(self._index)), not the
+        # primary key. Capture the requested fids and make sure the in-memory
+        # cache exists so fetchFeature() can resolve them locally.
+        ftype = self._request.filterType()
+        if ftype in (
+            QgsFeatureRequest.FilterFid,
+            QgsFeatureRequest.FilterFids,
+        ):
+            self._target_fids = (
+                [self._request.filterFid()]
+                if ftype == QgsFeatureRequest.FilterFid
+                else list(self._request.filterFids())
+            )
+            if not self._provider._features_loaded:
+                for _ in self._provider.getFeatures(QgsFeatureRequest()):
+                    pass
 
         if not self._provider._features_loaded:
             geom_column = self._provider.get_geometry_column()
@@ -142,30 +163,10 @@ class SFFeatureIterator(QgsAbstractFeatureIterator):
                 fields_name_for_query += ","
             self.index_geom_column = len(list_field_names)
 
-            # Create fid/fids list
-            feature_id_list = None
-            if (
-                self._request.filterType() == QgsFeatureRequest.FilterFid
-                or self._request.filterType() == QgsFeatureRequest.FilterFids
-            ):
-                feature_id_list = (
-                    [self._request.filterFid()]
-                    if self._request.filterType() == QgsFeatureRequest.FilterFid
-                    else self._request.filterFids()
-                )
-
+            # FilterFid/FilterFids are handled from the in-memory cache (see the
+            # top of __init__), never pushed down to SQL, because feature ids are
+            # fetch-order positions rather than primary-key values.
             where_clause_list = []
-            if feature_id_list is not None:
-                list_feature_id_string = ", ".join(str(x) for x in feature_id_list)
-                if self._provider.primary_key() == "":
-                    feature_clause = (
-                        f"sfindexsfrownumberauto in ({list_feature_id_string})"
-                    )
-                else:
-                    primary_key_name = list_field_names[self._provider.primary_key()]
-                    feature_clause = f"{quote_identifier(primary_key_name)} in ({list_feature_id_string})"
-
-                where_clause_list.append(feature_clause)
 
             self._expression = ""
             # Apply the filter expression. The raw QGIS expression text is
@@ -247,7 +248,7 @@ class SFFeatureIterator(QgsAbstractFeatureIterator):
             # it changes), so it is intentionally not part of this check.
             self._should_cache_features = (
                 not getattr(self._provider, "_load_all_rows", False)
-                and feature_id_list is None
+                and self._target_fids is None
                 and self._expression == ""
                 and filter_geom_clause == ""
             )
@@ -342,32 +343,55 @@ class SFFeatureIterator(QgsAbstractFeatureIterator):
         """
         try:
             if self._provider._features_loaded:
-                if (
-                    self._index < 0
-                    or self._index >= len(self._provider._features)
-                    or not self._provider.isValid()
-                ):
+                if not self._provider.isValid():
                     f.setValid(False)
                     return False
 
-                if self._request.filterType() == QgsFeatureRequest.FilterFid:
-                    _indx = self._request.filterFid()
-                else:
-                    _indx = self._index
-                local_feature: QgsFeature = self._provider._features[_indx]
+                features = self._provider._features
+                filter_rect = self._request.filterRect()
+
+                # FilterFid/FilterFids: feature ids are fetch-order positions
+                # into the cached feature list, so resolve them directly. This
+                # path manages its own index and returns immediately (it must
+                # not fall through to the sequential increment below).
+                if self._target_fids is not None:
+                    while self._index < len(self._target_fids):
+                        fid = self._target_fids[self._index]
+                        self._index += 1
+                        if fid < 0 or fid >= len(features):
+                            continue
+                        local_feature: QgsFeature = features[fid]
+                        if (
+                            filter_rect
+                            and not filter_rect.isNull()
+                            and not local_feature.geometry().intersects(filter_rect)
+                        ):
+                            continue
+                        f.setFields(self._provider.fields())
+                        f.setGeometry(local_feature.geometry())
+                        f.setId(local_feature.id())
+                        f.setAttributes(local_feature.attributes())
+                        f.setValid(True)
+                        return True
+                    f.setValid(False)
+                    return False
+
+                if self._index < 0 or self._index >= len(features):
+                    f.setValid(False)
+                    return False
+
+                local_feature: QgsFeature = features[self._index]
 
                 while (
-                    self._request.filterRect()
-                    and not self._request.filterRect().isNull()
-                    and not local_feature.geometry().intersects(
-                        self._request.filterRect()
-                    )
+                    filter_rect
+                    and not filter_rect.isNull()
+                    and not local_feature.geometry().intersects(filter_rect)
                 ):
                     self._index += 1
-                    if self._index >= len(self._provider._features):
+                    if self._index >= len(features):
                         f.setValid(False)
                         return False
-                    local_feature = self._provider._features[self._index]
+                    local_feature = features[self._index]
 
                 f.setFields(self._provider.fields())
                 f.setGeometry(local_feature.geometry())

--- a/sf_expression_functions.py
+++ b/sf_expression_functions.py
@@ -13,7 +13,7 @@ _REGISTERED_FUNCTIONS = []
 
 
 @qgsfunction(args=1, group="Snowflake", register=False)
-def sf_h3_resolution(values, context, parent, node):
+def sf_h3_resolution(values, context, parent):
     """Returns the resolution of an H3 index (integer 0-15).
 
     <h4>Syntax</h4>
@@ -35,7 +35,7 @@ def sf_h3_resolution(values, context, parent, node):
 
 
 @qgsfunction(args=1, group="Snowflake", register=False)
-def sf_h3_is_valid(values, context, parent, node):
+def sf_h3_is_valid(values, context, parent):
     """Returns True if the value is a valid H3 hex string.
 
     <h4>Syntax</h4>
@@ -55,7 +55,7 @@ def sf_h3_is_valid(values, context, parent, node):
 
 
 @qgsfunction(args=1, group="Snowflake", register=False)
-def sf_h3_to_string(values, context, parent, node):
+def sf_h3_to_string(values, context, parent):
     """Converts a numeric H3 index to its hex string representation.
 
     <h4>Syntax</h4>


### PR DESCRIPTION
## Summary
Merges the release fixes accumulated on `dev` into `main`:
- **1.0.22** – Fix feature-edit crash (`TypeError: list indices must be integers or slices, not str`) by resolving `FilterFid`/`FilterFids` from the in-memory feature cache instead of pushing them down to SQL as primary-key filters.
- **1.0.21** – Fix custom Snowflake H3 expression functions (removed the extra `node` parameter that QGIS never injects).
- **1.0.20** – Fix Import from Snowflake dropping rows for TIMESTAMP/DATE/TIME columns (coerce to QDateTime/QDate/QTime).

## Test plan
- [x] End-to-end feature testing via QGIS MCP: feature edit (FilterFid/FilterFids), edit→commit→re-read
- [x] Core provider reads, filters, subset, capabilities
- [x] All 6 processing algorithms (Execute SQL, Import incl. temporal, Buffer, H3, Spatial Join, Export)
- [x] H3 layer rendering, expression functions, locator, connection reuse, update check

Made with [Cursor](https://cursor.com)