### PR TITLE
Fix regression test for renamed cache-gate variable (CI fix)

### DIFF
--- a/test/test_issue_regressions.py
+++ b/test/test_issue_regressions.py
@@ -2062,7 +2062,7 @@ class TestFeatureCachePoisoning(unittest.TestCase):
         self.assertIn(
             'not getattr(self._provider, "_load_all_rows", False)', block
         )
-        self.assertIn("and feature_id_list is None", block)
+        self.assertIn("and self._target_fids is None", block)
         self.assertIn('and self._expression == ""', block)
         self.assertIn('and filter_geom_clause == ""', block)
 


### PR DESCRIPTION
## Summary
Follow-up to the 1.0.22 release: the feature-edit fix renamed the local `feature_id_list` to `self._target_fids` in the cache-eligibility gate, which broke the source-scraping assertion in `test_cache_gate_condition`, turning CI red on `dev` and `main`.

This updates the assertion to reference the new variable name. The fail-closed security property (feature cache is not reused for per-request fid filters) is unchanged. No functional/version change.

## Test plan
- [x] `python test/test_issue_regressions.py` → 168 tests OK locally

Made with [Cursor](https://cursor.com)