### PR TITLE
CI: bump checkout to v7 and setup-python to v6 (Node 24)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,10 @@ jobs:
       matrix:
         python-version: ["3.10", "3.12"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
## Summary
Clears the recurring GitHub Actions Node 20 deprecation warning by upgrading the two pinned actions in `.github/workflows/ci.yml` to their latest Node 24-based majors:
- `actions/checkout@v4` -> `@v7`
- `actions/setup-python@v5` -> `@v6`

GitHub-hosted `ubuntu-latest` runners already exceed the required runner version, so no other changes are needed. Infra-only change; no plugin version bump.

## Test plan
- [x] `dev` CI green with no "Node.js 20 is deprecated" annotation (run 29010139050)

Made with [Cursor](https://cursor.com)